### PR TITLE
User permission check by album rather than item

### DIFF
--- a/modules/gallery/helpers/item_rest.php
+++ b/modules/gallery/helpers/item_rest.php
@@ -80,7 +80,7 @@ class item_rest_Core {
     $orm->order_by($order_by);
 
     $result = array(
-      "url" => rest::url("item", $item),
+      "url" => $request->url,
       "entity" => $item->as_restful_array(),
       "relationships" => rest::relationships("item", $item));
     if ($item->is_album()) {


### PR DESCRIPTION
When checking item permissions, use the parent ID if $item->type != album. This way, we have a cache hit rather than a cache miss when you request several items (from the same album) in one go.

It feels like a safe fix, but it's hard (for me) to say without knowing whether there's any corner cases I'm not thinking about. 
