### PR TITLE
availability of the comments rss feeds is now configurable

### DIFF
--- a/modules/comment/controllers/admin_comments.php
+++ b/modules/comment/controllers/admin_comments.php
@@ -32,6 +32,8 @@ class Admin_Comments_Controller extends Admin_Controller {
     $form->validate();
     module::set_var("comment", "access_permissions",
                     $form->comment_settings->access_permissions->value);
+    module::set_var("comment", "rss_available",
+                    $form->comment_settings->rss_available->value);
     message::success(t("Comment settings updated"));
     url::redirect("admin/comments");
   }
@@ -45,6 +47,13 @@ class Admin_Comments_Controller extends Admin_Controller {
       ->options(array("everybody" => t("Everybody"),
                       "registered_users" => t("Only registered users")))
       ->selected(module::get_var("comment", "access_permissions"));
+    $comment_settings->dropdown("rss_available")
+      ->label(t("Which RSS feeds should be available?"))
+      ->options(array("both" => t("Both"),
+                      "newest" => t("Only All new comments"),
+                      "onitem" => t("Only Comments on item"),
+                      "none" => t("None")))
+      ->selected(module::get_var("comment", "rss_available"));
     $comment_settings->submit("save")->value(t("Save"));
     return $form;
   }

--- a/modules/comment/helpers/comment_installer.php
+++ b/modules/comment/helpers/comment_installer.php
@@ -48,7 +48,8 @@ class comment_installer {
 
     module::set_var("comment", "spam_caught", 0);
     module::set_var("comment", "access_permissions", "everybody");
-    module::set_version("comment", 4);
+    module::set_var("comment", "rss_available", "both");
+    module::set_version("comment", 5);
   }
 
   static function upgrade($version) {
@@ -74,6 +75,11 @@ class comment_installer {
       $db->query(
         "ALTER TABLE {comments} CHANGE `server_remote_host` `server_remote_host` varchar(255)");
       module::set_version("comment", $version = 4);
+    }
+
+    if ($version == 4) {
+      module::set_var("comment", "rss_available", "both");
+      module::set_version("comment", $version = 5);
     }
   }
 

--- a/modules/comment/helpers/comment_rss.php
+++ b/modules/comment/helpers/comment_rss.php
@@ -20,8 +20,16 @@
 
 class comment_rss_Core {
   static function available_feeds($item, $tag) {
-    $feeds["comment/newest"] = t("All new comments");
-    if ($item) {
+    $avail = module::get_var("comment", "rss_available");
+    if($avail == "none") {
+      return array();
+    }
+
+    if($avail == "both" || $avail == "newest") {
+      $feeds["comment/newest"] = t("All new comments");
+    }
+
+    if ($item && ($avail == "both" || $avail == "onitem")) {
       $feeds["comment/item/$item->id"] =
         t("Comments on %title", array("title" => html::purify($item->title)));
     }


### PR DESCRIPTION
i found it annoying that everybody could view all comments at once because there was no option to enable comments but disable (not showing) the corresponding automatic rss feed.
