### PR TITLE
Initial commit of a patch for Ticket #1764. as discussed here: https://gi

### DIFF
--- a/modules/gallery/controllers/albums.php
+++ b/modules/gallery/controllers/albums.php
@@ -69,6 +69,7 @@ class Albums_Controller extends Items_Controller {
             "item" => $album,
             "children" => $album->viewable()->children($page_size, $offset),
             "parents" => $album->parents()->as_array(), // view calls empty() on this
+            "breadcrumbs" => Breadcrumb::build_from_item($album),
             "children_count" => $children_count));
     $template->content = new View("album.html");
 

--- a/modules/gallery/controllers/movies.php
+++ b/modules/gallery/controllers/movies.php
@@ -43,6 +43,7 @@ class Movies_Controller extends Items_Controller {
             "children" => array(),
             "children_count" => 0,
             "parents" => $movie->parents()->as_array(),
+            "breadcrumbs" => Breadcrumb::build_from_item($movie),
             "next_item" => $next_item,
             "previous_item" => $previous_item,
             "sibling_count" => $movie->parent()->viewable()->children_count($where),

--- a/modules/gallery/controllers/photos.php
+++ b/modules/gallery/controllers/photos.php
@@ -43,6 +43,7 @@ class Photos_Controller extends Items_Controller {
             "children" => array(),
             "children_count" => 0,
             "parents" => $photo->parents()->as_array(),
+            "breadcrumbs" => Breadcrumb::build_from_item($photo),
             "next_item" => $next_item,
             "previous_item" => $previous_item,
             "sibling_count" => $photo->parent()->viewable()->children_count($where),

--- a/modules/gallery/libraries/Breadcrumb.php
+++ b/modules/gallery/libraries/Breadcrumb.php
@@ -1,0 +1,74 @@
+<?php defined("SYSPATH") or die("No direct script access.");
+/**
+ * Gallery - a web based photo album viewer and editor
+ * Copyright (C) 2000-2011 Bharat Mediratta
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+class Breadcrumb_Core {
+  public $title;
+  public $url;
+  public $id;
+  public $first;
+  public $last;
+
+  static function build_from_item($item) {
+    $breadcrumbs = array();
+    foreach ($item->parents() as $element) {
+      $breadcrumbs[] = new Breadcrumb($element->title, $element->url(), $element->id);
+    }
+
+    if (!empty($breadcrumbs)) {
+      $breadcrumbs[] = new Breadcrumb($item->title, $item->url(), $item->id);
+    }
+
+    return self::generate_show_query_strings($breadcrumbs);
+  }
+
+  /**
+   * This static function takes a list (variable arguments) of Breadcrumbs and builds a dynamic
+   * breadcrumb list.  Used to create a breadcrumb for dynamic albums. Will really be useful
+   * for the display context change.
+   */
+  static function build_from_list() {
+    return self::generate_show_query_strings(func_get_args());
+  }
+
+  private static function generate_show_query_strings($breadcrumbs) {
+    if (!empty($breadcrumbs)) {
+
+      end($breadcrumbs)->last = true;;
+      while ($breadcrumb = current($breadcrumbs)) {
+        if (isset($last_id) && $last_id > 0) {
+          $query = parse_url($breadcrumb->url, PHP_URL_QUERY);
+          $breadcrumb->url =  $breadcrumb->url . ($query ? "&" : "?") . "show={$last_id}";
+        }
+        $last_id = $breadcrumb->id;
+        $breadcrumb = prev($breadcrumbs);
+      }
+      $breadcrumbs[0]->first = true;
+    }
+
+    return $breadcrumbs;
+  }
+
+  public function __construct($title, $url, $id=0) {
+    $this->title = $title;
+    $this->url = $url;
+    $this->id = $id;
+    $this->first = false;
+    $this->last = false;
+  }
+}

--- a/modules/gallery/tests/Breadcrumb_Test.php
+++ b/modules/gallery/tests/Breadcrumb_Test.php
@@ -1,0 +1,51 @@
+<?php defined("SYSPATH") or die("No direct script access.");
+/**
+ * Gallery - a web based photo album viewer and editor
+ * Copyright (C) 2000-2011 Bharat Mediratta
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+class Breadcrumb_Test extends Gallery_Unit_Test_Case {
+  private $album;
+  private $item;
+
+  public function setup() {
+    $this->album = test::random_album();
+    $this->item = test::random_photo($this->album);
+    $this->album->reload();
+  }
+
+  public function teardown() {
+    $this->album = null;
+    $this->item = null;
+  }
+
+  public function build_breadcrumbs_for_item_test() {
+    $breadcrumbs = Breadcrumb::build_from_item($this->item);
+    $this->assert_equal("Gallery", $breadcrumbs[0]->title);
+    $this->assert_equal($this->album->title, $breadcrumbs[1]->title);
+    $this->assert_equal($this->item->title, $breadcrumbs[2]->title);
+  }
+
+  public function build_breadcrumbs_from_items_test() {
+    $breadcrumbs = Breadcrumb::build_from_list(
+      new Breadcrumb(item::root()->title, "/", item::root()->id),
+      new Breadcrumb($this->album->title, $this->album->relative_path(), $this->album->id),
+      new Breadcrumb($this->item->title, $this->item->relative_path(), $this->item->id));
+    $this->assert_equal("Gallery", $breadcrumbs[0]->title);
+    $this->assert_equal($this->album->title, $breadcrumbs[1]->title);
+    $this->assert_equal($this->item->title, $breadcrumbs[2]->title);
+  }
+}

--- a/modules/search/controllers/search.php
+++ b/modules/search/controllers/search.php
@@ -36,9 +36,14 @@ class Search_Controller extends Controller {
     $max_pages = max(ceil($count / $page_size), 1);
 
     $template = new Theme_View("page.html", "collection", "search");
+    $root = item::root();
+    $search_url = url::abs_site("search?q=" . urlencode($q));
     $template->set_global(array("page" => $page,
                                 "max_pages" => $max_pages,
                                 "page_size" => $page_size,
+                                "breadcrumbs" => Breadcrumb::build_from_list(
+                                  new Breadcrumb(item::root()->title, "/", item::root()->id),
+                                  new Breadcrumb($q, $search_url)),
                                 "children_count" => $count));
 
     $template->content = new View("search.html");

--- a/modules/tag/controllers/tag.php
+++ b/modules/tag/controllers/tag.php
@@ -40,6 +40,9 @@ class Tag_Controller extends Controller {
                                 "page_size" => $page_size,
                                 "tag" => $tag,
                                 "children" => $tag->items($page_size, $offset),
+                                "breadcrumbs" => Breadcrumb::build_from_list(
+                                  new Breadcrumb(item::root()->title, "/", item::root()->id),
+                                  new Breadcrumb($tag->name, $tag->url())),
                                 "children_count" => $children_count));
     $template->content = new View("dynamic.html");
     $template->content->title = t("Tag: %tag_name", array("tag_name" => $tag->name));

--- a/themes/wind/views/page.html.php
+++ b/themes/wind/views/page.html.php
@@ -107,28 +107,15 @@
           <?= $theme->header_bottom() ?>
         </div>
 
-        <? if ($theme->item() && !empty($parents)): ?>
+        <? if (!empty($breadcrumbs)): ?>
         <ul class="g-breadcrumbs">
-          <? $i = 0 ?>
-          <? foreach ($parents as $parent): ?>
-          <li<? if ($i == 0) print " class=\"g-first\"" ?>>
-            <? // Adding ?show=<id> causes Gallery3 to display the page
-               // containing that photo.  For now, we just do it for
-               // the immediate parent so that when you go back up a
-               // level you're on the right page. ?>
-            <a href="<?= $parent->url($parent->id == $theme->item()->parent_id ?
-                     "show={$theme->item()->id}" : null) ?>">
-              <? // limit the title length to something reasonable (defaults to 15) ?>
-              <?= html::purify(text::limit_chars($parent->title,
-                    module::get_var("gallery", "visible_title_length"))) ?>
-            </a>
-          </li>
-          <? $i++ ?>
+          <? foreach ($breadcrumbs as $breadcrumb): ?>
+           <li class="<?= $breadcrumb->last ? "g-active" : "" ?>
+                      <?= $breadcrumb->first ? "g-first" : "" ?>">
+            <? if (!$breadcrumb->last): ?> <a href="<?= $breadcrumb->url ?>"><? endif ?>
+            <?= html::purify(text::limit_chars($breadcrumb->title, module::get_var("gallery", "visible_title_length"))) ?>
+            <? if (!$breadcrumb->last): ?></a><? endif ?>
           <? endforeach ?>
-          <li class="g-active<? if ($i == 0) print " g-first" ?>">
-            <?= html::purify(text::limit_chars($theme->item()->title,
-                  module::get_var("gallery", "visible_title_length"))) ?>
-          </li>
         </ul>
         <? endif ?>
       </div>


### PR DESCRIPTION
Initial commit of a patch for Ticket #1764. as discussed here: https://github.com/gallery/gallery3/pull/58/files#r72949.

Create a Breadcrumb library which has two static methods for_item (which takes a an item and builds the entire
breadcrumb for the item) or build (which takes a variable number of Breadcrumb elements and creates a breadcrumb
based on the specified elements).

Used tag->url() to build the tag album url. Escaped the query string for the search. Tightened up the breadcrumb code
 in page.html.php.

When adding the show query parameter, we can't blindly concatenate using the ? separator.  We have to check that we
use a & if a query parameter already exists.
