### PR TITLE
[#1875] Active area of upload photo button less than 40% of text area only - not button

### DIFF
--- a/modules/gallery/css/gallery.css
+++ b/modules/gallery/css/gallery.css
@@ -39,6 +39,7 @@
 
 #g-add-photos-canvas object {
   z-index: 100;
+  padding: 0em;
 }
 
 #g-add-photos-canvas .uploadifyQueue {

--- a/modules/gallery/views/form_uploadify.html.php
+++ b/modules/gallery/views/form_uploadify.html.php
@@ -23,8 +23,8 @@
 
     if (swfobject.hasFlashPlayerVersion("<?= $flash_minimum_version ?>")) {
       $("#g-uploadify").uploadify({
-        width: 150,
-        height: 33,
+        width: 298,
+        height: 32,
         uploader: "<?= url::file("lib/uploadify/uploadify.swf") ?>",
         script: "<?= url::site("uploader/add_photo/{$album->id}") ?>",
         scriptData: <?= json_encode($script_data) ?>,


### PR DESCRIPTION
Fixes ticket #1875 (https://sourceforge.net/apps/trac/gallery/ticket/1875)

This ticket is related to the integration between Uploadify and Gallery for media uploads.  The real button to prompt the user for which photos to upload (via Uploadify) is a transparent SWF object, which sits on top of a dummy button to get the user to click the transparent SWF object.

There were two parts to this ticket
1. The Uploadify SWF object needs to be aligned with the top left corner of the dummy button.
2. The SWF object needs to span the full length and width of the dummy button.

The modified CSS file causes the SWF object to be aligned with the top left corner of the dummy button.  The modified form_uploadify.html.php file allows for the transparent SWF object to span the full size of the dummy button.
