### PR TITLE
Correction of event sent from Users_Controller::_get_change_email_form

### DIFF
--- a/modules/user/controllers/users.php
+++ b/modules/user/controllers/users.php
@@ -198,7 +198,7 @@ class Users_Controller extends Controller {
       ->error_messages("length", t("Your email address is too long"))
       ->error_messages("required", t("You must enter a valid email address"));
 
-    module::event("user_change_password_form", $user, $form);
+    module::event("user_change_email_form", $user, $form);
     $group->submit("")->value(t("Save"));
     return $form;
   }


### PR DESCRIPTION
It appears that there was a copy/paste error made in Users_Controller::_get_change_email_form (modules/user/controller/users.php).

In particular, the user_change_password_form, rather than user_change_email_form is being invoked. The lack of the user_change_email_form event hook also is a glaring omission in the xxx_form/xxx_form_completed pattern that appears for most of the form event handlers.

This shouldn't be causing any current problem as it appears that none of the current modules in github (gallery or gallery-contrib) actually handle either of these events. But, it could cause for a surprise for someone down the road.
