### PR TITLE
#1919 - change `convert -v` to `convert -version`

### DIFF
--- a/modules/gallery/helpers/graphics.php
+++ b/modules/gallery/helpers/graphics.php
@@ -335,7 +335,7 @@ class graphics_Core {
       // ImageMagick & GraphicsMagick
       $magick_kits = array(
           "imagemagick" => array(
-            "name" => "ImageMagick", "binary" => "convert", "version_arg" => "-v",
+            "name" => "ImageMagick", "binary" => "convert", "version_arg" => "-version",
             "version_regex" => "/Version: \S+ (\S+)/"),
           "graphicsmagick" => array(
             "name" => "GraphicsMagick", "binary" => "gm", "version_arg" => "version",


### PR DESCRIPTION
Fixes #1919, namely that the argument used to get the ImageMagick version is incorrect.  It's a trivial bug, as by default it gives the whole help info anyway, which starts with the version info, so the end result to Gallery is essentially the same.
