### PR TITLE
#1941, 1948 - Fix possible warnings in movie and graphics helpers, add functions to convert between seconds and hh:mm:ss.dd (and their unit tests).

### DIFF
--- a/modules/gallery/helpers/graphics.php
+++ b/modules/gallery/helpers/graphics.php
@@ -157,7 +157,7 @@ class graphics_Core {
         if ($input_item->is_movie()) {
           // Convert the movie filename to a JPG first, delete anything that might already be there
           $output_file = legal_file::change_extension($output_file, "jpg");
-          unlink($output_file);
+          @unlink($output_file);
           // Run movie_extract_frame events, which can either:
           //  - generate an output file, bypassing the ffmpeg-based movie::extract_frame
           //  - add to the options sent to movie::extract_frame (e.g. change frame extract time,

--- a/modules/gallery/tests/Movie_Helper_Test.php
+++ b/modules/gallery/tests/Movie_Helper_Test.php
@@ -1,0 +1,49 @@
+<?php defined("SYSPATH") or die("No direct script access.");
+/**
+ * Gallery - a web based photo album viewer and editor
+ * Copyright (C) 2000-2012 Bharat Mediratta
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+class Movie_Helper_Test extends Gallery_Unit_Test_Case {
+  public function seconds_to_hhmmssdd_test() {
+    $times = array("00:00:00.50" => 0.5,
+                   "00:00:06.00" => 6,
+                   "00:00:59.99" => 59.999,
+                   "00:01:00.00" => 60.001,
+                   "00:07:00.00" => 7 * 60,
+                   "00:45:19.00" => 45 * 60 + 19,
+                   "03:45:19.00" => 3 * 3600 + 45 * 60 + 19,
+                   "126:45:19.00" => 126 * 3600 + 45 * 60 + 19);
+    foreach ($times as $hhmmssdd => $seconds) {
+      $this->assert_equal($hhmmssdd, movie::seconds_to_hhmmssdd($seconds));
+    }
+  }
+
+  public function hhmmssdd_to_seconds_test() {
+    $times = array("0:00:00.01" => 0.01,
+                   "00:00:00.50" => 0.5,
+                   "00:00:06.00" => 6,
+                   "00:00:59.99" => 59.99,
+                   "00:01:00.00" => 60.00,
+                   "00:07:00.00" => 7 * 60,
+                   "00:45:19.00" => 45 * 60 + 19,
+                   "03:45:19.00" => 3 * 3600 + 45 * 60 + 19,
+                   "126:45:19.00" => 126 * 3600 + 45 * 60 + 19);
+    foreach ($times as $hhmmssdd => $seconds) {
+      $this->assert_equal($seconds, movie::hhmmssdd_to_seconds($hhmmssdd));
+    }
+  }
+}


### PR DESCRIPTION
Modifications in the fix for #1928 could cause warnings if error reporting is enabled. In production they're disabled anyway, but this should be cleaned up nevertheless.

Added helper functions to convert between a number of seconds and hh:mm:ss.dd (the format ffmpeg likes to use).

graphics helper: added "@" before unlink
movie helper: added three issets
movie helper: changed time formatting to avoid possible warnings and/or issues with the is_dst argument of date()
movie helper: added new helper functions for converting to/from hh:mm:ss.dd
