### PR TITLE
#1942 - Make data_rest and file_proxy more consistent

### DIFF
--- a/modules/gallery/controllers/file_proxy.php
+++ b/modules/gallery/controllers/file_proxy.php
@@ -100,6 +100,9 @@ class File_Proxy_Controller extends Controller {
       throw new Kohana_404_Exception();
     }
 
+    // Note: this code is roughly duplicated in data_rest, so if you modify this, please look to
+    // see if you should make the same change there as well.
+
     if ($type == "albums") {
       $file = $item->file_path();
     } else if ($type == "resizes") {

--- a/modules/gallery/helpers/data_rest.php
+++ b/modules/gallery/helpers/data_rest.php
@@ -32,27 +32,21 @@ class data_rest_Core {
       throw new Rest_Exception("Bad Request", 400, array("errors" => array("size" => "invalid")));
     }
 
-    switch ($p->size) {
-    case "thumb":
-      $file = $item->thumb_path();
-      break;
+    // Note: this code is roughly duplicated in file_proxy, so if you modify this, please look to
+    // see if you should make the same change there as well.
 
-    case "resize":
-      $file = $item->resize_path();
-      break;
-
-    case "full":
+    if ($p->size == "full") {
       $file = $item->file_path();
-      break;
+    } else if ($p->size == "resize") {
+      $file = $item->resize_path();
+    } else {
+      $file = $item->thumb_path();
     }
 
     if (!file_exists($file)) {
       throw new Kohana_404_Exception();
     }
 
-    // Note: this code is roughly duplicated in data_rest, so if you modify this, please look to
-    // see if you should make the same change there as well.
-    //
     // We don't have a cache buster in the url, so don't set cache headers here.
     // We don't need to save the session for this request
     Session::instance()->abort_save();


### PR DESCRIPTION
This pull is 100% cosmetic and has no functional changes.

By design, data_rest::get and file_proxy have many similarities because they both serve files. However, there are a few cosmetic inconsistencies between them that could be cleaned up a little.

Most notable is the documentation. In data_rest, there's a comment that says "Note: this code is roughly duplicated in data_rest..." where it should read file_proxy, and in file_proxy there is no corresponding comment.
