### PR TITLE
#1946, 1947 - Make altered names/slugs more user-friendly, make conflict-finding code check filenames with no extensions

### DIFF
--- a/installer/install.sql
+++ b/installer/install.sql
@@ -244,7 +244,7 @@ CREATE TABLE {modules} (
   KEY `weight` (`weight`)
 ) AUTO_INCREMENT=10 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
-INSERT INTO {modules} VALUES (1,1,'gallery',53,1);
+INSERT INTO {modules} VALUES (1,1,'gallery',54,1);
 INSERT INTO {modules} VALUES (2,1,'user',4,2);
 INSERT INTO {modules} VALUES (3,1,'comment',7,3);
 INSERT INTO {modules} VALUES (4,1,'organize',4,4);

--- a/modules/gallery/helpers/item.php
+++ b/modules/gallery/helpers/item.php
@@ -39,55 +39,28 @@ class item_Core {
       }
     }
 
-    $source->parent_id = $target->id;
-
-    // Moving may result in name or slug conflicts.  If that happens, try up to 5 times to pick a
-    // random name (or slug) to avoid the conflict.
     $orig_name = $source->name;
-    $orig_name_filename = pathinfo($source->name, PATHINFO_FILENAME);
-    $orig_name_extension = pathinfo($source->name, PATHINFO_EXTENSION);
-    $orig_slug = $source->slug;
-    for ($i = 0; $i < 5; $i++) {
-      try {
-        $source->save();
-        if ($orig_name != $source->name) {
-          switch ($source->type) {
-          case "album":
-            message::info(
-              t("Album <b>%old_name</b> renamed to <b>%new_name</b> to avoid a conflict",
-                array("old_name" => $orig_name, "new_name" => $source->name)));
-            break;
-
-          case "photo":
-            message::info(
-              t("Photo <b>%old_name</b> renamed to <b>%new_name</b> to avoid a conflict",
-                array("old_name" => $orig_name, "new_name" => $source->name)));
-            break;
-
-          case "movie":
-            message::info(
-              t("Movie <b>%old_name</b> renamed to <b>%new_name</b> to avoid a conflict",
-                array("old_name" => $orig_name, "new_name" => $source->name)));
-            break;
-          }
-        }
+    $source->parent_id = $target->id;
+    $source->save();
+    if ($orig_name != $source->name) {
+      switch ($source->type) {
+      case "album":
+        message::info(
+          t("Album <b>%old_name</b> renamed to <b>%new_name</b> to avoid a conflict",
+            array("old_name" => $orig_name, "new_name" => $source->name)));
         break;
-      } catch (ORM_Validation_Exception $e) {
-        $rand = rand(10, 99);
-        $errors = $e->validation->errors();
-        if (isset($errors["name"])) {
-          $source->name = $orig_name_filename . "-{$rand}." . $orig_name_extension;
-          unset($errors["name"]);
-        }
-        if (isset($errors["slug"])) {
-          $source->slug = $orig_slug . "-{$rand}";
-          unset($errors["slug"]);
-        }
 
-        if ($errors) {
-          // There were other validation issues-- we don't know how to handle those
-          throw $e;
-        }
+      case "photo":
+        message::info(
+          t("Photo <b>%old_name</b> renamed to <b>%new_name</b> to avoid a conflict",
+            array("old_name" => $orig_name, "new_name" => $source->name)));
+        break;
+
+      case "movie":
+        message::info(
+          t("Movie <b>%old_name</b> renamed to <b>%new_name</b> to avoid a conflict",
+            array("old_name" => $orig_name, "new_name" => $source->name)));
+        break;
       }
     }
 

--- a/modules/gallery/models/item.php
+++ b/modules/gallery/models/item.php
@@ -338,10 +338,11 @@ class Item_Model_Core extends ORM_MPTT {
         if (empty($this->slug)) {
           $this->slug = item::convert_filename_to_slug(pathinfo($this->name, PATHINFO_FILENAME));
 
-          // If the filename is all invalid characters, then the slug may be empty here.  Pick a
-          // random value.
+          // If the filename is all invalid characters, then the slug may be empty here.  We set a
+          // generic name ("photo", "movie", or "album") based on its type, then rely on
+          // check_and_fix_conflicts to ensure it doesn't conflict with another name.
           if (empty($this->slug)) {
-            $this->slug = (string)rand(1000, 9999);
+            $this->slug = $this->type;
           }
         }
 
@@ -362,7 +363,7 @@ class Item_Model_Core extends ORM_MPTT {
           }
         }
 
-        $this->_randomize_name_or_slug_on_conflict();
+        $this->_check_and_fix_conflicts();
 
         parent::save();
 
@@ -382,16 +383,6 @@ class Item_Model_Core extends ORM_MPTT {
 
         case "photo":
         case "movie":
-          // The thumb or resize may already exist in the case where a movie and a photo generate
-          // a thumbnail of the same name (eg, foo.flv movie and foo.jpg photo will generate
-          // foo.jpg thumbnail).  If that happens, randomize and save again.
-          if (file_exists($this->resize_path()) ||
-              file_exists($this->thumb_path())) {
-            $pi = pathinfo($this->name);
-            $this->name = $pi["filename"] . "-" . random::int() . "." . $pi["extension"];
-            parent::save();
-          }
-
           copy($this->data_file, $this->file_path());
           break;
         }
@@ -435,7 +426,7 @@ class Item_Model_Core extends ORM_MPTT {
           $this->relative_url_cache = null;
         }
 
-        $this->_randomize_name_or_slug_on_conflict();
+        $this->_check_and_fix_conflicts();
 
         parent::save();
 
@@ -528,30 +519,60 @@ class Item_Model_Core extends ORM_MPTT {
 
   /**
    * Check to see if there's another item that occupies the same name or slug that this item
-   * intends to use, and if so choose a new name/slug while preserving the extension.
-   * @todo Improve this.  Random numbers are not user friendly
+   * intends to use, and if so choose a new name/slug while preserving the extension.  Since this
+   * checks the name without its extension, it covers possible collisions with thumbs and resizes
+   * as well (e.g. between the thumbs of movie "foo.flv" and photo "foo.jpg").
    */
-  private function _randomize_name_or_slug_on_conflict() {
-    $base_name = pathinfo($this->name, PATHINFO_FILENAME);
-    $base_ext = pathinfo($this->name, PATHINFO_EXTENSION);
-    $base_slug = $this->slug;
-    while (ORM::factory("item")
-           ->where("parent_id", "=", $this->parent_id)
-           ->where("id", $this->id ? "<>" : "IS NOT", $this->id)
-           ->and_open()
-           ->where("name", "=", $this->name)
-           ->or_where("slug", "=", $this->slug)
-           ->close()
-           ->find()->id) {
-      $rand = random::int();
-      if ($base_ext) {
-        $this->name = "$base_name-$rand.$base_ext";
-      } else {
-        $this->name = "$base_name-$rand";
+  private function _check_and_fix_conflicts() {
+    $suffix_num = 1;
+    $suffix = "";
+    if ($this->is_album()) {
+      while (db::build()
+             ->from("items")
+             ->where("parent_id", "=", $this->parent_id)
+             ->where("id", $this->id ? "<>" : "IS NOT", $this->id)
+             ->and_open()
+             ->where("name", "=", "{$this->name}{$suffix}")
+             ->or_where("slug", "=", "{$this->slug}{$suffix}")
+             ->close()
+             ->count_records()) {
+        $suffix = "-" . (($suffix_num <= 99) ? sprintf("%02d", $suffix_num++) : random::int());
       }
-      $this->slug = "$base_slug-$rand";
-      $this->relative_path_cache = null;
-      $this->relative_url_cache = null;
+      if ($suffix) {
+        $this->name = "{$this->name}{$suffix}";
+        $this->slug = "{$this->slug}{$suffix}";
+        $this->relative_path_cache = null;
+        $this->relative_url_cache = null;
+      }
+    } else {
+      // Split the filename into its base and extension.  This uses a regexp similar to
+      // legal_file::change_extension (which isn't always the same as pathinfo).
+      if (preg_match("/^(.*)(\.[^\.\/]*?)$/", $this->name, $matches)) {
+        $base_name = $matches[1];
+        $extension = $matches[2]; // includes a leading dot
+      } else {
+        $base_name = $this->name;
+        $extension = "";
+      }
+      $base_name_escaped = Database::escape_for_like($base_name);
+      // Note: below query uses LIKE with wildcard % at end, which is still sargable (i.e. quick)
+      while (db::build()
+             ->from("items")
+             ->where("parent_id", "=", $this->parent_id)
+             ->where("id", $this->id ? "<>" : "IS NOT", $this->id)
+             ->and_open()
+             ->where("name", "LIKE", "{$base_name_escaped}{$suffix}.%")
+             ->or_where("slug", "=", "{$this->slug}{$suffix}")
+             ->close()
+             ->count_records()) {
+        $suffix = "-" . (($suffix_num <= 99) ? sprintf("%02d", $suffix_num++) : random::int());
+      }
+      if ($suffix) {
+        $this->name = "{$base_name}{$suffix}{$extension}";
+        $this->slug = "{$this->slug}{$suffix}";
+        $this->relative_path_cache = null;
+        $this->relative_url_cache = null;
+      }
     }
   }
 
@@ -871,14 +892,32 @@ class Item_Model_Core extends ORM_MPTT {
       }
     }
 
-    if (db::build()
-        ->from("items")
-        ->where("parent_id", "=", $this->parent_id)
-        ->where("name", "=", $this->name)
-        ->merge_where($this->id ? array(array("id", "<>", $this->id)) : null)
-        ->count_records()) {
-      $v->add_error("name", "conflict");
-      return;
+    if ($this->is_album()) {
+      if (db::build()
+          ->from("items")
+          ->where("parent_id", "=", $this->parent_id)
+          ->where("name", "=", $this->name)
+          ->merge_where($this->id ? array(array("id", "<>", $this->id)) : null)
+          ->count_records()) {
+        $v->add_error("name", "conflict");
+        return;
+      }
+    } else {
+      if (preg_match("/^(.*)(\.[^\.\/]*?)$/", $this->name, $matches)) {
+        $base_name = $matches[1];
+      } else {
+        $base_name = $this->name;
+      }
+      $base_name_escaped = Database::escape_for_like($base_name);
+      if (db::build()
+          ->from("items")
+          ->where("parent_id", "=", $this->parent_id)
+          ->where("name", "LIKE", "{$base_name_escaped}.%")
+          ->merge_where($this->id ? array(array("id", "<>", $this->id)) : null)
+          ->count_records()) {
+        $v->add_error("name", "conflict");
+        return;
+      }
     }
 
     if ($this->parent_id == 1 && Kohana::auto_load("{$this->slug}_Controller")) {

--- a/modules/gallery/module.info
+++ b/modules/gallery/module.info
@@ -1,6 +1,6 @@
 name = "Gallery 3"
 description = "Gallery core application"
-version = 53
+version = 54
 author_name = "Gallery Team"
 author_url = "http://codex.galleryproject.org/Gallery:Team"
 info_url = "http://codex.galleryproject.org/Gallery3:Modules:gallery"

--- a/modules/gallery/tests/Item_Model_Test.php
+++ b/modules/gallery/tests/Item_Model_Test.php
@@ -136,19 +136,6 @@ class Item_Model_Test extends Gallery_Unit_Test_Case {
     $this->assert_true(false, "Shouldn't get here");
   }
 
-  public function item_rename_over_existing_name_gets_uniqified_test() {
-    // Create a test photo
-    $item = test::random_photo();
-    $item2 = test::random_photo();
-
-    $item->name = $item2->name;
-    $item->save();
-
-    // foo.jpg should become foo-####.jpg
-    $this->assert_true(
-      preg_match("/" . str_replace(".jpg", "", $item2->name) . "-\d+\.jpg/", $item->name));
-  }
-
   public function move_album_test() {
     $album2 = test::random_album();
     $album1 = test::random_album($album2);
@@ -205,7 +192,7 @@ class Item_Model_Test extends Gallery_Unit_Test_Case {
     $this->assert_equal($fullsize_file, file_get_contents($photo->file_path()));
   }
 
-  public function move_album_with_conflicting_target_gets_uniqified_test() {
+  public function move_album_with_conflicting_target_gets_uniquified_test() {
     $album = test::random_album();
     $source = test::random_album_unsaved($album);
     $source->name = $album->name;
@@ -217,9 +204,9 @@ class Item_Model_Test extends Gallery_Unit_Test_Case {
     $source->parent_id = item::root()->id;
     $source->save();
 
-    // foo should become foo-####
-    $this->assert_true(preg_match("/{$album->name}-\d+/", $source->name));
-    $this->assert_true(preg_match("/{$album->slug}-\d+/", $source->slug));
+    // foo should become foo-01
+    $this->assert_same("{$album->name}-01", $source->name);
+    $this->assert_same("{$album->slug}-01", $source->slug);
   }
 
   public function move_album_fails_wrong_target_type_test() {
@@ -239,7 +226,7 @@ class Item_Model_Test extends Gallery_Unit_Test_Case {
     $this->assert_true(false, "Shouldn't get here");
   }
 
-  public function move_photo_with_conflicting_target_gets_uniqified_test() {
+  public function move_photo_with_conflicting_target_gets_uniquified_test() {
     $photo1 = test::random_photo();
     $album = test::random_album();
     $photo2 = test::random_photo_unsaved($album);
@@ -247,17 +234,16 @@ class Item_Model_Test extends Gallery_Unit_Test_Case {
     $photo2->save();
 
     // $photo1 and $photo2 have the same name, so if we move $photo1 into the root they should
-    // conflict and get uniqified.
+    // conflict and get uniquified.
 
     $photo2->parent_id = item::root()->id;
     $photo2->save();
 
-    // foo.jpg should become foo-####.jpg
-    $this->assert_true(
-      preg_match("/" . str_replace(".jpg", "", $photo1->name) . "-\d+\.jpg/", $photo2->name));
+    // foo.jpg should become foo-01.jpg
+    $this->assert_same(pathinfo($photo1->name, PATHINFO_FILENAME) . "-01.jpg", $photo2->name);
 
-    // foo should become foo
-    $this->assert_true(preg_match("/{$photo1->slug}/", $photo2->name));
+    // foo should become foo-01
+    $this->assert_same("{$photo1->slug}-01", $photo2->slug);
   }
 
   public function move_album_inside_descendent_fails_test() {
@@ -534,5 +520,165 @@ class Item_Model_Test extends Gallery_Unit_Test_Case {
     $album = test::random_album_unsaved(item::root());
     $album->name = $album->name . ".foo.bar";
     $album->save();
+  }
+
+  public function no_conflict_when_parents_different_test() {
+    $parent1 = test::random_album();
+    $parent2 = test::random_album();
+    $photo1 = test::random_photo($parent1);
+    $photo2 = test::random_photo($parent2);
+
+    $photo2->name = $photo1->name;
+    $photo2->slug = $photo1->slug;
+    $photo2->save();
+
+    // photo2 has same name and slug as photo1 but different parent - no conflict.
+    $this->assert_same($photo1->name, $photo2->name);
+    $this->assert_same($photo1->slug, $photo2->slug);
+  }
+
+  public function fix_conflict_when_names_identical_test() {
+    $parent = test::random_album();
+    $photo1 = test::random_photo($parent);
+    $photo2 = test::random_photo($parent);
+
+    $photo1_orig_base = pathinfo($photo1->name, PATHINFO_FILENAME);
+    $photo2_orig_slug = $photo2->slug;
+
+    $photo2->name = $photo1->name;
+    $photo2->save();
+
+    // photo2 has same name as photo1 - conflict resolved by renaming with -01.
+    $this->assert_same("{$photo1_orig_base}-01.jpg", $photo2->name);
+    $this->assert_same("{$photo2_orig_slug}-01", $photo2->slug);
+  }
+
+  public function fix_conflict_when_slugs_identical_test() {
+    $parent = test::random_album();
+    $photo1 = test::random_photo($parent);
+    $photo2 = test::random_photo($parent);
+
+    $photo2_orig_base = pathinfo($photo2->name, PATHINFO_FILENAME);
+
+    $photo2->slug = $photo1->slug;
+    $photo2->save();
+
+    // photo2 has same slug as photo1 - conflict resolved by renaming with -01.
+    $this->assert_same("{$photo2_orig_base}-01.jpg", $photo2->name);
+    $this->assert_same("{$photo1->slug}-01", $photo2->slug);
+  }
+
+  public function no_conflict_when_parents_different_for_albums_test() {
+    $parent1 = test::random_album();
+    $parent2 = test::random_album();
+    $album1 = test::random_album($parent1);
+    $album2 = test::random_album($parent2);
+
+    $album2->name = $album1->name;
+    $album2->slug = $album1->slug;
+    $album2->save();
+
+    // album2 has same name and slug as album1 but different parent - no conflict.
+    $this->assert_same($album1->name, $album2->name);
+    $this->assert_same($album1->slug, $album2->slug);
+  }
+
+  public function fix_conflict_when_names_identical_for_albums_test() {
+    $parent = test::random_album();
+    $album1 = test::random_album($parent);
+    $album2 = test::random_album($parent);
+
+    $album2_orig_slug = $album2->slug;
+
+    $album2->name = $album1->name;
+    $album2->save();
+
+    // album2 has same name as album1 - conflict resolved by renaming with -01.
+    $this->assert_same("{$album1->name}-01", $album2->name);
+    $this->assert_same("{$album2_orig_slug}-01", $album2->slug);
+  }
+
+  public function fix_conflict_when_slugs_identical_for_albums_test() {
+    $parent = test::random_album();
+    $album1 = test::random_album($parent);
+    $album2 = test::random_album($parent);
+
+    $album2_orig_name = $album2->name;
+
+    $album2->slug = $album1->slug;
+    $album2->save();
+
+    // album2 has same slug as album1 - conflict resolved by renaming with -01.
+    $this->assert_same("{$album2_orig_name}-01", $album2->name);
+    $this->assert_same("{$album1->slug}-01", $album2->slug);
+  }
+
+  public function no_conflict_when_base_names_identical_between_album_and_photo_test() {
+    $parent = test::random_album();
+    $album = test::random_album($parent);
+    $photo = test::random_photo($parent);
+
+    $photo_orig_slug = $photo->slug;
+
+    $photo->name = "{$album->name}.jpg";
+    $photo->save();
+
+    // photo has same base name as album - no conflict.
+    $this->assert_same("{$album->name}.jpg", $photo->name);
+    $this->assert_same($photo_orig_slug, $photo->slug);
+  }
+
+  public function fix_conflict_when_full_names_identical_between_album_and_photo_test() {
+    $parent = test::random_album();
+    $photo = test::random_photo($parent);
+    $album = test::random_album($parent);
+
+    $album_orig_slug = $album->slug;
+
+    $album->name = $photo->name;
+    $album->save();
+
+    // album has same full name as album - conflict resolved by renaming with -01.
+    $this->assert_same("{$photo->name}-01", $album->name);
+    $this->assert_same("{$album_orig_slug}-01", $album->slug);
+  }
+
+  public function fix_conflict_when_slugs_identical_between_album_and_photo_test() {
+    $parent = test::random_album();
+    $album = test::random_album($parent);
+    $photo = test::random_photo($parent);
+
+    $photo_orig_base = pathinfo($photo->name, PATHINFO_FILENAME);
+
+    $photo->slug = $album->slug;
+    $photo->save();
+
+    // photo has same slug as album - conflict resolved by renaming with -01.
+    $this->assert_same("{$photo_orig_base}-01.jpg", $photo->name);
+    $this->assert_same("{$album->slug}-01", $photo->slug);
+  }
+
+  public function fix_conflict_when_base_names_identical_between_jpg_png_flv_test() {
+    $parent = test::random_album();
+    $item1 = test::random_photo($parent);
+    $item2 = test::random_photo($parent);
+    $item3 = test::random_movie($parent);
+
+    $item1_orig_base = pathinfo($item1->name, PATHINFO_FILENAME);
+    $item2_orig_slug = $item2->slug;
+    $item3_orig_slug = $item3->slug;
+
+    $item2->set_data_file(MODPATH . "gallery/images/graphicsmagick.png");
+    $item2->name = "{$item1_orig_base}.png";
+    $item2->save();
+
+    $item3->name = "{$item1_orig_base}.flv";
+    $item3->save();
+
+    // item2 and item3 have same base name as item1 - conflict resolved by renaming with -01 and -02.
+    $this->assert_same("{$item1_orig_base}-01.png", $item2->name);
+    $this->assert_same("{$item2_orig_slug}-01", $item2->slug);
+    $this->assert_same("{$item1_orig_base}-02.flv", $item3->name);
+    $this->assert_same("{$item3_orig_slug}-02", $item3->slug);
   }
 }


### PR DESCRIPTION
- Reduced from four places that alter names/slugs to two (one to populate empty slugs, one to handle conflicting names/slugs).
- For empty slugs, fill with generic human-readable name (e.g. "photo") instead of random value.
- For conflicting names/slugs, add suffix that's sequential (e.g. "-001") instead of random. This is handled by the function Item_Model::_randomize_name_or_slug_on_conflict, which should be renamed to Item_Model::_change_name_or_slug_on_conflict.
- Made conflict-finding code check filenames with no extensions.
