### PR TITLE
#1944 - Fix possible warnings in legal_file::get_photo_types_by_extension and legal_file::get_movie_types_by_extension.

### DIFF
--- a/modules/gallery/helpers/legal_file.php
+++ b/modules/gallery/helpers/legal_file.php
@@ -25,13 +25,14 @@ class legal_file_Core {
    *
    * @param string $extension (opt.) - return MIME of extension; if not given, return complete array
    */
-  static function get_photo_types_by_extension($extension=NULL) {
+  static function get_photo_types_by_extension($extension=null) {
     $types_by_extension_wrapper = new stdClass();
     $types_by_extension_wrapper->types_by_extension = array(
       "jpg" => "image/jpeg", "jpeg" => "image/jpeg", "gif" => "image/gif", "png" => "image/png");
     module::event("photo_types_by_extension", $types_by_extension_wrapper);
     if ($extension) {
       // return matching MIME type
+      $extension = strtolower($extension);
       if (isset($types_by_extension_wrapper->types_by_extension[$extension])) {
         return $types_by_extension_wrapper->types_by_extension[$extension];
       } else {
@@ -50,13 +51,14 @@ class legal_file_Core {
    *
    * @param string $extension (opt.) - return MIME of extension; if not given, return complete array
    */
-  static function get_movie_types_by_extension($extension=NULL) {
+  static function get_movie_types_by_extension($extension=null) {
     $types_by_extension_wrapper = new stdClass();
     $types_by_extension_wrapper->types_by_extension = array(
       "flv" => "video/x-flv", "mp4" => "video/mp4", "m4v" => "video/x-m4v");
     module::event("movie_types_by_extension", $types_by_extension_wrapper);
     if ($extension) {
       // return matching MIME type
+      $extension = strtolower($extension);
       if (isset($types_by_extension_wrapper->types_by_extension[$extension])) {
         return $types_by_extension_wrapper->types_by_extension[$extension];
       } else {

--- a/modules/gallery/tests/Legal_File_Helper_Test.php
+++ b/modules/gallery/tests/Legal_File_Helper_Test.php
@@ -18,6 +18,43 @@
  * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA  02110-1301, USA.
  */
 class Legal_File_Helper_Test extends Gallery_Unit_Test_Case {
+  public function get_photo_types_by_extension_test() {
+    // Valid extensions return their corresponding mimes, invalid extensions return null
+    $tests = array("jpg" => "image/jpeg",
+                   "JPG" => "image/jpeg",
+                   "jpeg" => "image/jpeg",
+                   "png" => "image/png",
+                   "Png" => "image/png",
+                   "gif" => "image/gif",
+                   "tif" => null,
+                   "mp4" => null,
+                   "php" => null,
+                   "php.jpg" => null);
+    foreach ($tests as $extension => $mime_type) {
+      $this->assert_equal($mime_type, legal_file::get_photo_types_by_extension($extension));
+    }
+    // No extension returns full array
+    $this->assert_equal(4, count(legal_file::get_photo_types_by_extension()));
+  }
+
+  public function get_movie_types_by_extension_test() {
+    // Valid extensions return their corresponding mimes, invalid extensions return null
+    $tests = array("flv" => "video/x-flv",
+                   "FLV" => "video/x-flv",
+                   "mp4" => "video/mp4",
+                   "Mp4" => "video/mp4",
+                   "m4v" => "video/x-m4v",
+                   "avi" => null,
+                   "jpg" => null,
+                   "php" => null,
+                   "php.flv" => null);
+    foreach ($tests as $extension => $mime_type) {
+      $this->assert_equal($mime_type, legal_file::get_movie_types_by_extension($extension));
+    }
+    // No extension returns full array
+    $this->assert_equal(3, count(legal_file::get_movie_types_by_extension()));
+  }
+
   public function change_extension_test() {
     $this->assert_equal("foo.jpg", legal_file::change_extension("foo.png", "jpg"));
   }


### PR DESCRIPTION
Fix possible warnings in legal_file::get_photo_types_by_extension and legal_file::get_movie_types_by_extension.

Added unit tests for these two functions, too.
