### PR TITLE
#1949 - Fix album thumb mime types given by data_rest and file_proxy

### DIFF
--- a/modules/gallery/controllers/file_proxy.php
+++ b/modules/gallery/controllers/file_proxy.php
@@ -126,8 +126,8 @@ class File_Proxy_Controller extends Controller {
 
     expires::set(2592000, $item->updated);  // 30 days
 
-    // Dump out the image.  If the item is a movie, then its thumbnail will be a JPG.
-    if ($item->is_movie() && $type != "albums") {
+    // Dump out the image.  If the item is a movie or album, then its thumbnail will be a JPG.
+    if (($item->is_movie() || $item->is_album()) && $type == "thumbs") {
       header("Content-Type: image/jpeg");
     } else {
       header("Content-Type: $item->mime_type");

--- a/modules/gallery/helpers/data_rest.php
+++ b/modules/gallery/helpers/data_rest.php
@@ -57,13 +57,11 @@ class data_rest_Core {
       return;
     }
 
-    // Dump out the image.  If the item is a movie, then its thumbnail will be a JPG.
-    if ($item->is_movie() && $p->size == "thumb") {
+    // Dump out the image.  If the item is a movie or album, then its thumbnail will be a JPG.
+    if (($item->is_movie() || $item->is_album()) && $p->size == "thumb") {
       header("Content-Type: image/jpeg");
-    } else if ($item->is_album()) {
-      header("Content-Type: " . $item->album_cover()->mime_type);
     } else {
-      header("Content-Type: {$item->mime_type}");
+      header("Content-Type: $item->mime_type");
     }
     Kohana::close_buffers(false);
 


### PR DESCRIPTION
Correct result: always "image/jpeg"
Old data_rest result: mime of cover item
Old file_proxy result: mime of album item (null)
