### PR TITLE
#1951 - Make metadata generation more flexible (photo and movie helpers).

### DIFF
--- a/modules/gallery/helpers/graphics.php
+++ b/modules/gallery/helpers/graphics.php
@@ -195,9 +195,8 @@ class graphics_Core {
         } else {
           copy(MODPATH . "gallery/images/missing_photo.png", $item->thumb_path());
         }
-        $dims = getimagesize($item->thumb_path());
-        $item->thumb_width = $dims[0];
-        $item->thumb_height = $dims[1];
+        list ($item->thumb_width, $item->thumb_height) =
+          photo::get_file_metadata($item->thumb_path());
       }
 
       if (!empty($ops["resize"]))  {
@@ -206,9 +205,8 @@ class graphics_Core {
         } else {
           copy(MODPATH . "gallery/images/missing_photo.png", $item->resize_path());
         }
-        $dims = getimagesize($item->resize_path());
-        $item->resize_width = $dims[0];
-        $item->resize_height = $dims[1];
+        list ($item->resize_width, $item->resize_height) =
+          photo::get_file_metadata($item->resize_path());
       }
       $item->save();
     } catch (Exception $e) {

--- a/modules/gallery/helpers/photo.php
+++ b/modules/gallery/helpers/photo.php
@@ -80,20 +80,61 @@ class photo_Core {
 
   /**
    * Return the width, height, mime_type and extension of the given image file.
+   * Metadata is first generated using getimagesize (or the legal_file mapping if it fails),
+   * then can be modified by other modules using photo_get_file_metadata events.
+   *
+   * This function and its use cases are symmetric to those of photo::get_file_metadata.
+   *
+   * @param  string $file_path
+   * @return array  array($width, $height, $mime_type, $extension)
+   *
+   * Use cases in detail:
+   *   Input is standard photo type (jpg/png/gif)
+   *     -> return metadata from getimagesize()
+   *   Input is *not* standard photo type that is supported by getimagesize (e.g. tif, bmp...)
+   *     -> return metadata from getimagesize()
+   *   Input is *not* standard photo type that is *not* supported by getimagesize but is legal
+   *     -> return zero width and height, mime type and extension according to legal_file
+   *   Input is *not* standard photo type that is *not* supported by getimagesize and is *not* legal
+   *     -> return zero width and height, null mime type and extension
+   *   Input is not readable or does not exist
+   *     -> throw exception
+   * Note: photo_get_file_metadata events can change any of the above cases (except the last one).
    */
   static function get_file_metadata($file_path) {
-    $image_info = getimagesize($file_path);
-    if ($image_info) {
-      $width = $image_info[0];
-      $height = $image_info[1];
-      $mime_type = $image_info["mime"];
-      $extension = image_type_to_extension($image_info[2], false);
-      return array($width, $height, $mime_type, $extension);
-    } else {
-      // getimagesize failed - use legal_file mapping instead.
-      $extension = strtolower(pathinfo($file_path, PATHINFO_EXTENSION));
-      $mime_type = legal_file::get_photo_types_by_extension($extension);
-      return array(0, 0, $mime_type, $extension);
+    if (!is_readable($file_path)) {
+      throw new Exception("@todo UNREADABLE_FILE");
     }
+
+    $metadata = new stdClass();
+    if ($image_info = getimagesize($file_path)) {
+      // getimagesize worked - use its results.
+      $metadata->width = $image_info[0];
+      $metadata->height = $image_info[1];
+      $metadata->mime_type = $image_info["mime"];
+      $metadata->extension = image_type_to_extension($image_info[2], false);
+      // We prefer jpg instead of jpeg (which is returned by image_type_to_extension).
+      if ($metadata->extension == "jpeg") {
+        $metadata->extension = "jpg";
+      }
+    } else {
+      // getimagesize failed - try to use legal_file mapping instead.
+      $extension = pathinfo($file_path, PATHINFO_EXTENSION);
+      if (!$extension ||
+          (!$metadata->mime_type = legal_file::get_photo_types_by_extension($extension))) {
+        // Extension is empty or illegal.
+        $metadata->extension = null;
+        $metadata->mime_type = null;
+      } else {
+        // Extension is legal (and mime is already set above).
+        $metadata->extension = strtolower($extension);
+      }
+      $metadata->width = 0;
+      $metadata->height = 0;
+    }
+
+    // Run photo_get_file_metadata events which can modify the class, then return results.
+    module::event("photo_get_file_metadata", $file_path, $metadata);
+    return array($metadata->width, $metadata->height, $metadata->mime_type, $metadata->extension);
   }
 }

--- a/modules/gallery/tests/Movie_Helper_Test.php
+++ b/modules/gallery/tests/Movie_Helper_Test.php
@@ -46,4 +46,36 @@ class Movie_Helper_Test extends Gallery_Unit_Test_Case {
       $this->assert_equal($seconds, movie::hhmmssdd_to_seconds($hhmmssdd));
     }
   }
+
+  public function get_file_metadata_test() {
+    $movie = test::random_movie();
+    $this->assert_equal(array(360, 288, "video/x-flv", "flv", 6.00),
+                        movie::get_file_metadata($movie->file_path()));
+  }
+
+  public function get_file_metadata_with_non_existent_file_test() {
+    try {
+      $metadata = movie::get_file_metadata(MODPATH . "gallery/tests/this_does_not_exist");
+      $this->assert_true(false, "Shouldn't get here");
+    } catch (Exception $e) {
+      // pass
+    }
+  }
+
+  public function get_file_metadata_with_no_extension_test() {
+    copy(MODPATH . "gallery/tests/test.flv", TMPPATH . "test_flv_with_no_extension");
+    $this->assert_equal(array(360, 288, null, null, 6.00),
+                        movie::get_file_metadata(TMPPATH . "test_flv_with_no_extension"));
+  }
+
+  public function get_file_metadata_with_illegal_extension_test() {
+    $this->assert_equal(array(0, 0, null, null, 0),
+                        movie::get_file_metadata(MODPATH . "gallery/tests/Movie_Helper_Test.php"));
+  }
+
+  public function get_file_metadata_with_illegal_extension_but_valid_file_contents_test() {
+    copy(MODPATH . "gallery/tests/test.flv", TMPPATH . "test_flv_with_php_extension.php");
+    $this->assert_equal(array(360, 288, null, null, 6.00),
+                        movie::get_file_metadata(TMPPATH . "test_flv_with_php_extension.php"));
+  }
 }

--- a/modules/gallery/tests/Photo_Helper_Test.php
+++ b/modules/gallery/tests/Photo_Helper_Test.php
@@ -1,0 +1,56 @@
+<?php defined("SYSPATH") or die("No direct script access.");
+/**
+ * Gallery - a web based photo album viewer and editor
+ * Copyright (C) 2000-2013 Bharat Mediratta
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+class Photo_Helper_Test extends Gallery_Unit_Test_Case {
+  public function get_file_metadata_test() {
+    $photo = test::random_photo();
+    $this->assert_equal(array(1024, 768, "image/jpeg", "jpg"),
+                        photo::get_file_metadata($photo->file_path()));
+  }
+
+  public function get_file_metadata_with_non_existent_file_test() {
+    try {
+      $metadata = photo::get_file_metadata(MODPATH . "gallery/tests/this_does_not_exist");
+      $this->assert_true(false, "Shouldn't get here");
+    } catch (Exception $e) {
+      // pass
+    }
+  }
+
+  public function get_file_metadata_with_no_extension_test() {
+    copy(MODPATH . "gallery/tests/test.jpg", TMPPATH . "test_jpg_with_no_extension");
+    $this->assert_equal(array(1024, 768, "image/jpeg", "jpg"),
+                        photo::get_file_metadata(TMPPATH . "test_jpg_with_no_extension"));
+  }
+
+  public function get_file_metadata_with_illegal_extension_test() {
+    $this->assert_equal(array(0, 0, null, null),
+                        photo::get_file_metadata(MODPATH . "gallery/tests/Photo_Helper_Test.php"));
+  }
+
+  public function get_file_metadata_with_illegal_extension_but_valid_file_contents_test() {
+    // This ensures that we correctly "re-type" files with invalid extensions if the contents
+    // themselves are valid.  This is needed to ensure that issues similar to those corrected by
+    // ticket #1855, where an image that looked valid (header said jpg) with a php extension was
+    // previously accepted without changing its extension, do not arise and cause security issues.
+    copy(MODPATH . "gallery/tests/test.jpg", TMPPATH . "test_jpg_with_php_extension.php");
+    $this->assert_equal(array(1024, 768, "image/jpeg", "jpg"),
+                        photo::get_file_metadata(TMPPATH . "test_jpg_with_php_extension.php"));
+  }
+}


### PR DESCRIPTION
- added photo_get_file_metadata and movie_get_file_metadata events
- modified photo::get_file_metadata and movie::get_file_metadata to use them
- redirected other photo metadata calls in core to photo::get_file_metadata (the helper function already exists, but in many places getimagesize is still called directly)
- added some unit tests (neither of the functions above currently have one)
