### PR TITLE
Add batch tagging via the organize module

### DIFF
--- a/modules/organize/controllers/organize.php
+++ b/modules/organize/controllers/organize.php
@@ -182,6 +182,28 @@ class Organize_Controller extends Controller {
     json::reply(null);
   }
 
+  function tag() {
+    access::verify_csrf();
+    $input = Input::instance();
+
+    foreach (explode(",", $input->post("item_ids")) as $item_id) {
+      $item = ORM::factory("item", $item_id);
+      if (access::can("edit", $item)) {
+        // Assuming the user can view/edit the current item, loop
+        // through each tag that was submitted and apply it to
+        // the current item.
+        foreach (explode(",", $input->post("tag_names")) as $tag_name) {
+          $tag_name = trim($tag_name);
+          if ($tag_name) {
+            tag::add($item, $tag_name);
+          }
+        }
+      }
+    }
+
+    json::reply(null);
+  }
+
   private function _get_tree($item, $selected) {
     $tree = array();
     $children = $item->viewable()

--- a/modules/organize/views/organize_frame.html.php
+++ b/modules/organize/views/organize_frame.html.php
@@ -104,9 +104,33 @@
       });
     }
 
+    var tag_selected_items = function(tag) {
+      var nodes = thumb_data_view.getSelectedNodes();
+      var item_ids = [];
+      for (var i = 0; i != nodes.length; i++) {
+        var node = Ext.fly(nodes[i]);
+        item_ids.push(get_id_from_node(node));
+      }
+      start_busy(<?= t("Tagging...")->for_js() ?>);
+      Ext.Ajax.request({
+        url: '<?= url::site("organize/tag") ?>',
+        method: "post",
+        success: function() {
+          stop_busy();
+          reload_album_data();
+        },
+        failure: show_generic_error,
+        params: {
+          item_ids: item_ids.join(","),
+          tag_names: tag,
+          csrf: '<?= access::csrf_token() ?>'
+        }
+      });
+    };
+
     var delete_selected_items = function() {
       var nodes = thumb_data_view.getSelectedNodes();
-      item_ids = [];
+      var item_ids = [];
       for (var i = 0; i != nodes.length; i++) {
         var node = Ext.fly(nodes[i]);
         item_ids.push(get_id_from_node(node));
@@ -254,6 +278,7 @@
           });
         },
         "selectionchange": function(v, selections) {
+          tag_button.setDisabled(!selections.length || !current_album_editable || !tag_textfield.getValue());
           delete_button.setDisabled(!selections.length || !current_album_editable);
         }
       },
@@ -330,6 +355,31 @@
       displayField: "value"
     });
 
+    var tag_textfield = new Ext.form.TextField({
+      flex: 4,
+      enableKeyEvents: true,
+      listeners: {
+        "keyup": function(v, e) {
+          var nodes = thumb_data_view.getSelectedNodes();
+          tag_button.setDisabled(!nodes.length || !current_album_editable || !tag_textfield.getValue());
+        }
+      }
+    });
+    
+    var tag_button = new Ext.Button({
+      flex: 2,
+        text: <?= t("Tag")->for_js() ?>,
+        cls: "x-btn-text-icon",
+        id: "tag-button",
+        disabled: true,
+        listeners: {
+          "click": function() {
+            tag_selected_items(tag_textfield.getValue());
+            return true;
+          }
+        }
+    });
+
     var delete_button = new Ext.Button({
       flex: 2,
       text: <?= t("Delete")->for_js() ?>,
@@ -375,10 +425,24 @@
             sort_column_combobox,
             sort_order_combobox
           ]
-        }, {
+        }, 
+<? if (module::is_active("tag")): ?>
+        {
+          xtype: "spacer",
+          flex: 3 
+        },
+        tag_textfield,
+        tag_button,
+        {
+          xtype: "spacer",
+          flex: 1
+        },
+<? else: ?>
+        {
           xtype: "spacer",
           flex: 10
         },
+<? endif ?>
         delete_button,
         {
           xtype: "button",


### PR DESCRIPTION
This pull request enables (if tags are enabled) a text field and button to batch tag selected images through the Organize module.
