### PR TITLE
#1954 - Skip buffer calls for unit tests of file_proxy and data_rest.

### DIFF
--- a/modules/gallery/controllers/file_proxy.php
+++ b/modules/gallery/controllers/file_proxy.php
@@ -147,22 +147,21 @@ class File_Proxy_Controller extends Controller {
       header("Content-Type: $item->mime_type");
     }
 
-    // Don't use Kohana::close_buffers(false) here because that only closes all the buffers
-    // that Kohana started.  We want to close *all* buffers at this point because otherwise we're
-    // going to buffer up whatever file we're proxying (and it may be very large).  This may
-    // affect embedding or systems with PHP's output_buffering enabled.
-    while (ob_get_level()) {
-      Kohana_Log::add("error","".print_r(ob_get_level(),1));
-      if (!@ob_end_clean()) {
-        // ob_end_clean() can return false if the buffer can't be removed for some reason
-        // (zlib output compression buffers sometimes cause problems).
-        break;
-      }
-    }
-
     if (TEST_MODE) {
       return $file;
     } else {
+      // Don't use Kohana::close_buffers(false) here because that only closes all the buffers
+      // that Kohana started.  We want to close *all* buffers at this point because otherwise we're
+      // going to buffer up whatever file we're proxying (and it may be very large).  This may
+      // affect embedding or systems with PHP's output_buffering enabled.
+      while (ob_get_level()) {
+        Kohana_Log::add("error","".print_r(ob_get_level(),1));
+        if (!@ob_end_clean()) {
+          // ob_end_clean() can return false if the buffer can't be removed for some reason
+          // (zlib output compression buffers sometimes cause problems).
+          break;
+        }
+      }
       readfile($file);
     }
   }

--- a/modules/gallery/helpers/data_rest.php
+++ b/modules/gallery/helpers/data_rest.php
@@ -57,13 +57,14 @@ class data_rest_Core {
     } else {
       header("Content-Type: $item->mime_type");
     }
-    Kohana::close_buffers(false);
 
-    if (isset($p->encoding) && $p->encoding == "base64") {
-      print base64_encode(file_get_contents($file));
+    if (TEST_MODE) {
+      return $file;
     } else {
-      if (TEST_MODE) {
-        return $file;
+      Kohana::close_buffers(false);
+
+      if (isset($p->encoding) && $p->encoding == "base64") {
+        print base64_encode(file_get_contents($file));
       } else {
         readfile($file);
       }


### PR DESCRIPTION
Moved the "if (TEST_MODE)" statement before the buffer calls in file_proxy and data_rest.
This has no impact on normal use, but will make the unit tests more compatible with different server/PHP configurations.
Note: We do not have to skip setting the headers, which means we can build unit tests around them if we wish.
