### PR TITLE
#1955 - Make unit test photos unique.

### DIFF
--- a/modules/gallery/tests/Item_Model_Test.php
+++ b/modules/gallery/tests/Item_Model_Test.php
@@ -66,7 +66,7 @@ class Item_Model_Test extends Gallery_Unit_Test_Case {
   }
 
   public function rename_photo_test() {
-    $item = test::random_photo();
+    $item = test::random_unique_photo();
     $original_name = $item->name;
 
     $thumb_file = file_get_contents($item->thumb_path());
@@ -89,7 +89,7 @@ class Item_Model_Test extends Gallery_Unit_Test_Case {
 
   public function rename_album_test() {
     $album = test::random_album();
-    $photo = test::random_photo($album);
+    $photo = test::random_unique_photo($album);
     $album->reload();
 
     $thumb_file = file_get_contents($photo->thumb_path());
@@ -152,7 +152,7 @@ class Item_Model_Test extends Gallery_Unit_Test_Case {
   public function move_album_test() {
     $album2 = test::random_album();
     $album1 = test::random_album($album2);
-    $photo = test::random_photo($album1);
+    $photo = test::random_unique_photo($album1);
 
     $thumb_file = file_get_contents($photo->thumb_path());
     $resize_file = file_get_contents($photo->resize_path());
@@ -180,7 +180,7 @@ class Item_Model_Test extends Gallery_Unit_Test_Case {
 
   public function move_photo_test() {
     $album1 = test::random_album();
-    $photo  = test::random_photo($album1);
+    $photo  = test::random_unique_photo($album1);
 
     $album2 = test::random_album();
 

--- a/modules/gallery_unit_test/helpers/test.php
+++ b/modules/gallery_unit_test/helpers/test.php
@@ -63,6 +63,34 @@ class test_Core {
     return test::random_photo_unsaved($parent)->save()->reload();
   }
 
+  // If a test compares photo file contents (i.e. file_get_contents), it's best to use this
+  // function to guarantee uniqueness.
+  static function random_unique_photo_unsaved($parent=null) {
+    $rand = test::random_string(6);
+    $photo = ORM::factory("item");
+    $photo->type = "photo";
+    $photo->parent_id = $parent ? $parent->id : 1;
+    if (function_exists("gd_info")) {
+      // Make image unique - color the black dot of test.jpg to the 6-digit hex code of rand.
+      $image = imagecreatefromjpeg(MODPATH . "gallery/tests/test.jpg");
+      imagefilter($image, IMG_FILTER_COLORIZE,
+        hexdec(substr($rand, 0, 2)), hexdec(substr($rand, 2, 2)), hexdec(substr($rand, 4, 2)));
+      imagejpeg($image, TMPPATH . "test_$rand.jpg");
+      imagedestroy($image);
+      $photo->set_data_file(TMPPATH . "test_$rand.jpg");
+    } else {
+      // Just use the black dot.
+      $photo->set_data_file(MODPATH . "gallery/tests/test.jpg");
+    }
+    $photo->name = "name_$rand.jpg";
+    $photo->title = "title_$rand";
+    return $photo;
+  }
+
+  static function random_unique_photo($parent=null) {
+    return test::random_unique_photo_unsaved($parent)->save()->reload();
+  }
+
   static function random_user($password="password") {
     $rand = "name_" . test::random_string(6);
     return identity::create_user($rand, $rand, $password, "$rand@rand.com");


### PR DESCRIPTION
- Modified test::random_photo and test::random_photo_unsaved to, by default, uniquify the test photos.
- Uniquified the black dot of test.jpg by coloring it with the six-digit hex code already used to name the random photos (e.g. "name_a48801.jpg").
- Modified replace_data_file_test and replace_data_file_test in Item_Model_Test to turn off uniquify (they need to know the exact filesize a priori).

Unit tests now take about ~10-20% longer to run, but we can be certain that all photos are unique.
