### PR TITLE
#1956 - Escape LIKE queries (for _ and %).

### DIFF
--- a/modules/g2_import/controllers/g2.php
+++ b/modules/g2_import/controllers/g2.php
@@ -49,7 +49,7 @@ class G2_Controller extends Controller {
         if ($view == "core.DownloadItem") {
           $where[] = array("resource_type", "IN", array("file", "resize", "thumbnail", "full"));
         } else if ($view) {
-          $where[] = array("g2_url", "like", "%g2_view=$view%");
+          $where[] = array("g2_url", "LIKE", "%" . Database::escape_for_like("g2_view=$view") . "%");
         } // else: Assuming that the first search hit is sufficiently good.
       } else if ($path) {
         $where = array(array("g2_url", "IN", array($path, str_replace(" ", "+", $path))));

--- a/modules/gallery/helpers/item_rest.php
+++ b/modules/gallery/helpers/item_rest.php
@@ -64,7 +64,7 @@ class item_rest_Core {
     }
 
     if (isset($p->name)) {
-      $orm->where("name", "LIKE", "%{$p->name}%");
+      $orm->where("name", "LIKE", "%" . Database::escape_for_like($p->name) . "%");
     }
 
     if (isset($p->type)) {

--- a/modules/gallery/libraries/MY_Database.php
+++ b/modules/gallery/libraries/MY_Database.php
@@ -88,4 +88,14 @@ abstract class Database extends Database_Core {
   static function set_default_instance($db) {
     self::$instances["default"] = $db;
   }
+
+  /**
+   * Escape LIKE queries, add wildcards.  In MySQL queries using LIKE, _ and % characters are
+   * treated as wildcards similar to ? and *, respectively.  Therefore, we need to escape _, %,
+   * and \ (the escape character itself).
+   */
+  static function escape_for_like($value) {
+    // backslash must go first to avoid double-escaping
+    return addcslashes($value, '\_%');
+  }
 }

--- a/modules/gallery/libraries/drivers/Cache/Database.php
+++ b/modules/gallery/libraries/drivers/Cache/Database.php
@@ -69,7 +69,7 @@ class Cache_Database_Driver extends Cache_Driver {
       ->select()
       ->from("caches");
     foreach ($tags as $tag) {
-      $db->where("tags", "LIKE", "%<$tag>%");
+      $db->where("tags", "LIKE", "%" . Database::escape_for_like("<$tag>") . "%");
     }
     $db_result = $db->execute();
 
@@ -139,7 +139,7 @@ class Cache_Database_Driver extends Cache_Driver {
       // Delete all caches
     } else if ($is_tag === true) {
       foreach ($keys as $tag) {
-        $db->where("tags", "LIKE", "%<$tag>%");
+        $db->where("tags", "LIKE", "%" . Database::escape_for_like("<$tag>") . "%");
       }
     } else {
       $db->where("key", "IN", $keys);

--- a/modules/gallery/tests/Database_Test.php
+++ b/modules/gallery/tests/Database_Test.php
@@ -147,6 +147,12 @@ class Database_Test extends Gallery_Unit_Test_Case {
     $sql = str_replace("\n", " ", $sql);
     $this->assert_same("UPDATE [test_tables] SET [name] = [Test Name] WHERE [1] = [1]", $sql);
   }
+
+  function escape_for_like_test() {
+    // Note: literal double backslash is written as \\\
+    $this->assert_same('basic\_test', Database::escape_for_like("basic_test"));
+    $this->assert_same('\\\100\%\_test/', Database::escape_for_like('\100%_test/'));
+  }
 }
 
 class Database_Mock extends Database {

--- a/modules/tag/controllers/tags.php
+++ b/modules/tag/controllers/tags.php
@@ -52,7 +52,7 @@ class Tags_Controller extends Controller {
     $limit = Input::instance()->get("limit");
     $tag_part = ltrim(end($tag_parts));
     $tag_list = ORM::factory("tag")
-      ->where("name", "LIKE", "{$tag_part}%")
+      ->where("name", "LIKE", Database::escape_for_like($tag_part) . "%")
       ->order_by("name", "ASC")
       ->limit($limit)
       ->find_all();


### PR DESCRIPTION
In MySQL queries, _ and % characters are treated as wildcards (similar to ? and *, respectively).
- Added escape_for_like function to MY_Database.php
- Added unit test to Database_Test
- Corrected the five unescaped instances in the code using this function.
