### PR TITLE
#1964 - TMPPATH is mis-defined in index.php.

### DIFF
--- a/index.php
+++ b/index.php
@@ -106,7 +106,7 @@ if (PHP_SAPI == "cli") {
   define("TEST_MODE", 0);
   define("VARPATH", realpath("var") . "/");
 }
-define("TMPPATH", VARPATH . "/tmp/");
+define("TMPPATH", VARPATH . "tmp/");
 
 if (file_exists("local.php")) {
   include("local.php");


### PR DESCRIPTION
TMPPATH is currently defined with a double-backslash.

VARPATH is defined by:
define("VARPATH", realpath("var") . "/");

Then, TMPPATH is defined by:
define("TMPPATH", VARPATH . "/tmp/");

... which results in something like .../gallery/var//tmp/

Yikes!!! It's a good thing PHP is fool-proof enough that this hasn't caused too many issues to date.
