### PR TITLE
#1966 - "Fix your Gallery" shows 60/59 items completed.

### DIFF
--- a/modules/gallery/helpers/gallery_task.php
+++ b/modules/gallery/helpers/gallery_task.php
@@ -612,7 +612,7 @@ class gallery_task_Core {
         break;
 
       case self::FIX_STATE_RUN_MISSING_ACCESS_CACHES:
-        $stack = explode(" ", $task->get("stack"));
+        $stack = array_filter(explode(" ", $task->get("stack"))); // filter removes empty/zero ids
         if (!empty($stack)) {
           $id = array_pop($stack);
           $access_cache = ORM::factory("access_cache");


### PR DESCRIPTION
- Fixed counter in gallery_task::fix that was often one too many.

For FIX_STATE_RUN_MISSING_ACCESS_CACHES, changed this:
$stack = explode(" ", $task->get("stack"));
To this:
$stack = array_filter(explode(" ", $task->get("stack")));
