### PR TITLE
#1945 - Extend legal_file helper functions.

### DIFF
--- a/modules/gallery/controllers/uploader.php
+++ b/modules/gallery/controllers/uploader.php
@@ -69,7 +69,7 @@ class Uploader_Controller extends Controller {
 
         $path_info = @pathinfo($temp_filename);
         if (array_key_exists("extension", $path_info) &&
-            in_array(strtolower($path_info["extension"]), legal_file::get_movie_extensions())) {
+            legal_file::get_movie_extensions($path_info["extension"])) {
           $item->type = "movie";
           $item->save();
           log::success("content", t("Added a movie"),

--- a/modules/gallery/models/item.php
+++ b/modules/gallery/models/item.php
@@ -879,16 +879,9 @@ class Item_Model_Core extends ORM_MPTT {
         return;
       }
 
-      if ($this->is_photo()) {
-        if (!in_array(strtolower($ext), legal_file::get_photo_extensions())) {
-          $v->add_error("name", "illegal_data_file_extension");
-        }
-      }
-
-      if ($this->is_movie()) {
-        if (!in_array(strtolower($ext), legal_file::get_movie_extensions())) {
-          $v->add_error("name", "illegal_data_file_extension");
-        }
+      if ($this->is_photo() && !legal_file::get_photo_extensions($ext) ||
+          $this->is_movie() && !legal_file::get_movie_extensions($ext)) {
+        $v->add_error("name", "illegal_data_file_extension");
       }
     }
 

--- a/modules/gallery/tests/Legal_File_Helper_Test.php
+++ b/modules/gallery/tests/Legal_File_Helper_Test.php
@@ -40,6 +40,63 @@ class Legal_File_Helper_Test extends Gallery_Unit_Test_Case {
     $this->assert_equal(3, count(legal_file::get_movie_types_by_extension()));
   }
 
+  public function get_types_by_extension_test() {
+    $this->assert_equal("image/jpeg", legal_file::get_types_by_extension("jpg"));  // photo
+    $this->assert_equal("video/x-flv", legal_file::get_types_by_extension("FLV")); // movie
+    $this->assert_equal(null, legal_file::get_types_by_extension("php"));          // invalid
+    $this->assert_equal(null, legal_file::get_types_by_extension("php.flv"));      // invalid w/ .
+
+    // No extension returns full array
+    $this->assert_equal(7, count(legal_file::get_types_by_extension()));
+  }
+
+  public function get_photo_extensions_test() {
+    $this->assert_equal(true, legal_file::get_photo_extensions("jpg"));      // regular
+    $this->assert_equal(true, legal_file::get_photo_extensions("JPG"));      // all caps
+    $this->assert_equal(true, legal_file::get_photo_extensions("Png"));      // some caps
+    $this->assert_equal(false, legal_file::get_photo_extensions("php"));     // invalid
+    $this->assert_equal(false, legal_file::get_photo_extensions("php.jpg")); // invalid w/ .
+
+    // No extension returns full array
+    $this->assert_equal(4, count(legal_file::get_photo_extensions()));
+  }
+
+  public function get_movie_extensions_test() {
+    $this->assert_equal(true, legal_file::get_movie_extensions("flv"));      // regular
+    $this->assert_equal(true, legal_file::get_movie_extensions("FLV"));      // all caps
+    $this->assert_equal(true, legal_file::get_movie_extensions("Mp4"));      // some caps
+    $this->assert_equal(false, legal_file::get_movie_extensions("php"));     // invalid
+    $this->assert_equal(false, legal_file::get_movie_extensions("php.jpg")); // invalid w/ .
+
+    // No extension returns full array
+    $this->assert_equal(3, count(legal_file::get_movie_extensions()));
+  }
+
+  public function get_extensions_test() {
+    $this->assert_equal(true, legal_file::get_extensions("jpg"));      // photo
+    $this->assert_equal(true, legal_file::get_extensions("FLV"));      // movie
+    $this->assert_equal(false, legal_file::get_extensions("php"));     // invalid
+    $this->assert_equal(false, legal_file::get_extensions("php.jpg")); // invalid w/ .
+
+    // No extension returns full array
+    $this->assert_equal(7, count(legal_file::get_extensions()));
+  }
+
+  public function get_filters_test() {
+    // All 7 extensions both uppercase and lowercase
+    $this->assert_equal(14, count(legal_file::get_filters()));
+  }
+
+  public function get_photo_types_test() {
+    // Note that this is one *less* than photo extensions since jpeg and jpg have the same mime.
+    $this->assert_equal(3, count(legal_file::get_photo_types()));
+  }
+
+  public function get_movie_types_test() {
+    // Note that this is one *more* than movie extensions since video/flv is added.
+    $this->assert_equal(4, count(legal_file::get_movie_types()));
+  }
+
   public function change_extension_test() {
     $this->assert_equal("foo.jpg", legal_file::change_extension("foo.png", "jpg"));
   }

--- a/modules/server_add/controllers/server_add.php
+++ b/modules/server_add/controllers/server_add.php
@@ -61,7 +61,7 @@ class Server_Add_Controller extends Admin_Controller {
         }
         if (!is_dir($file)) {
           $ext = strtolower(pathinfo($file, PATHINFO_EXTENSION));
-          if (!in_array($ext, legal_file::get_extensions())) {
+          if (!legal_file::get_extensions($ext)) {
             continue;
           }
         }
@@ -169,7 +169,7 @@ class Server_Add_Controller extends Admin_Controller {
           foreach ($child_paths as $child_path) {
             if (!is_dir($child_path)) {
               $ext = strtolower(pathinfo($child_path, PATHINFO_EXTENSION));
-              if (!in_array($ext, legal_file::get_extensions()) || !filesize($child_path)) {
+              if (!legal_file::get_extensions($ext) || !filesize($child_path)) {
                 // Not importable, skip it.
                 continue;
               }
@@ -255,7 +255,7 @@ class Server_Add_Controller extends Admin_Controller {
         } else {
           try {
             $extension = strtolower(pathinfo($name, PATHINFO_EXTENSION));
-            if (in_array($extension, legal_file::get_photo_extensions())) {
+            if (legal_file::get_photo_extensions($extension)) {
               $photo = ORM::factory("item");
               $photo->type = "photo";
               $photo->parent_id = $parent->id;
@@ -265,7 +265,7 @@ class Server_Add_Controller extends Admin_Controller {
               $photo->owner_id = $owner_id;
               $photo->save();
               $entry->item_id = $photo->id;
-            } else if (in_array($extension, legal_file::get_movie_extensions())) {
+            } else if (legal_file::get_movie_extensions($extension)) {
               $movie = ORM::factory("item");
               $movie->type = "movie";
               $movie->parent_id = $parent->id;


### PR DESCRIPTION
- Added get_types_by_extension function, which is a merged version of get...types_by_extension functions (similar to get_extensions).
- Added optional extension argument to get...extensions functions similar to get...types_by_extension functions.
- Added unit tests.  Now, every legal_file function has one.
- Restructured helper file a bit, including adding caches.
- Added array_unique to get...types (derived from get...types_by_extension, which can be many-to-one).
- Edited server_add, uploader, and item model to use new functionality.
