### PR TITLE
#1971 - Make resequence_child_weights_test unit test more reliable.

### DIFF
--- a/modules/gallery/tests/Item_Helper_Test.php
+++ b/modules/gallery/tests/Item_Helper_Test.php
@@ -237,7 +237,10 @@ class Item_Helper_Test extends Gallery_Unit_Test_Case {
   }
 
   public function resequence_child_weights_test() {
-    $album = test::random_album();
+    $album = test::random_album_unsaved();
+    $album->sort_column = "id";
+    $album->save();
+
     $photo1 = test::random_photo($album);
     $photo2 = test::random_photo($album);
     $this->assert_true($photo2->weight > $photo1->weight);


### PR DESCRIPTION
- Set the sort_column of the parent album to id, which has no possibility of being identical between the two photos.

Now, the reweighting will reverse the order even if they were created during the same second.
