### PR TITLE
#1974 - Add option to make all resizes and/or thumbs jpg.

### DIFF
--- a/installer/install.sql
+++ b/installer/install.sql
@@ -245,7 +245,7 @@ CREATE TABLE {modules} (
   KEY `weight` (`weight`)
 ) AUTO_INCREMENT=10 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
-INSERT INTO {modules} VALUES (1,1,'gallery',55,1);
+INSERT INTO {modules} VALUES (1,1,'gallery',56,1);
 INSERT INTO {modules} VALUES (2,1,'user',4,2);
 INSERT INTO {modules} VALUES (3,1,'comment',7,3);
 INSERT INTO {modules} VALUES (4,1,'organize',4,4);
@@ -383,7 +383,7 @@ CREATE TABLE {vars} (
   `value` text,
   PRIMARY KEY (`id`),
   UNIQUE KEY `module_name` (`module_name`,`name`)
-) AUTO_INCREMENT=46 DEFAULT CHARSET=utf8;
+) AUTO_INCREMENT=48 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 INSERT INTO {vars} VALUES (NULL,'gallery','active_site_theme','wind');
 INSERT INTO {vars} VALUES (NULL,'gallery','active_admin_theme','admin_wind');
@@ -417,6 +417,8 @@ INSERT INTO {vars} VALUES (NULL,'gallery','extra_binary_paths','/usr/local/bin:/
 INSERT INTO {vars} VALUES (NULL,'gallery','timezone',NULL);
 INSERT INTO {vars} VALUES (NULL,'gallery','lock_timeout','1');
 INSERT INTO {vars} VALUES (NULL,'gallery','movie_extract_frame_time','3');
+INSERT INTO {vars} VALUES (NULL,'gallery','make_all_resizes_jpg','0');
+INSERT INTO {vars} VALUES (NULL,'gallery','make_all_thumbs_jpg','0');
 INSERT INTO {vars} VALUES (NULL,'gallery','blocks_site_sidebar','a:4:{i:10;a:2:{i:0;s:7:\"gallery\";i:1;s:8:\"language\";}i:11;a:2:{i:0;s:4:\"info\";i:1;s:8:\"metadata\";}i:12;a:2:{i:0;s:3:\"rss\";i:1;s:9:\"rss_feeds\";}i:13;a:2:{i:0;s:3:\"tag\";i:1;s:3:\"tag\";}}');
 INSERT INTO {vars} VALUES (NULL,'gallery','identity_provider','user');
 INSERT INTO {vars} VALUES (NULL,'user','minimum_password_length','5');

--- a/modules/gallery/helpers/data_rest.php
+++ b/modules/gallery/helpers/data_rest.php
@@ -60,11 +60,15 @@ class data_rest_Core {
     // We don't need to save the session for this request
     Session::instance()->abort_save();
 
-    // Dump out the image.  If the item is a movie or album, then its thumbnail will be a JPG.
-    if (($item->is_movie() || $item->is_album()) && $p->size == "thumb") {
-      header("Content-Type: image/jpeg");
-    } else {
+    // Dump out the image.
+    if (($p->size == "full") || ($item->is_photo() &&
+        (($p->size == "resize") && !module::get_var("gallery", "make_all_resizes_jpg", 0)) ||
+        (($p->size == "thumb") && !module::get_var("gallery", "make_all_thumbs_jpg", 0)))) {
+      // Full-size item or resize/thumb of photo that isn't converted to jpg - use original mime
       header("Content-Type: $item->mime_type");
+    } else {
+      // Resize/thumb of album, movie, or photo that has been converted to jpg - mime is jpg
+      header("Content-Type: image/jpeg");
     }
 
     if (TEST_MODE) {

--- a/modules/gallery/helpers/gallery_installer.php
+++ b/modules/gallery/helpers/gallery_installer.php
@@ -315,6 +315,8 @@ class gallery_installer {
     module::set_var("gallery", "timezone", null);
     module::set_var("gallery", "lock_timeout", 1);
     module::set_var("gallery", "movie_extract_frame_time", 3);
+    module::set_var("gallery", "make_all_resizes_jpg", 0);
+    module::set_var("gallery", "make_all_thumbs_jpg", 0);
   }
 
   static function upgrade($version) {
@@ -789,6 +791,11 @@ class gallery_installer {
       module::set_version("gallery", $version = 55);
     }
 
+    if ($version == 55) {
+      module::set_var("gallery", "make_all_resizes_jpg", 0);
+      module::set_var("gallery", "make_all_thumbs_jpg", 0);
+      module::set_version("gallery", $version = 56);
+    }
   }
 
   static function uninstall() {

--- a/modules/gallery/models/item.php
+++ b/modules/gallery/models/item.php
@@ -182,12 +182,13 @@ class Item_Model_Core extends ORM_MPTT {
    */
   public function thumb_path() {
     $base = VARPATH . "thumbs/" . urldecode($this->relative_path());
-    if ($this->is_photo()) {
+    if ($this->is_photo() && ($this->mime_type == "image/jpeg" ||
+        !module::get_var("gallery", "make_all_thumbs_jpg", 0))) {
       return $base;
     } else if ($this->is_album()) {
       return $base . "/.album.jpg";
-    } else if ($this->is_movie()) {
-      // Replace the extension with jpg
+    } else {
+      // Replace the extension with jpg for non-jpg photos if make_all_thumbs_jpg set and all movies
       return legal_file::change_extension($base, "jpg");
     }
   }
@@ -207,12 +208,13 @@ class Item_Model_Core extends ORM_MPTT {
     $cache_buster = $this->_cache_buster($this->thumb_path());
     $relative_path = "var/thumbs/" . $this->relative_path();
     $base = ($full_uri ? url::abs_file($relative_path) : url::file($relative_path));
-    if ($this->is_photo()) {
+    if ($this->is_photo() && ($this->mime_type == "image/jpeg" ||
+        !module::get_var("gallery", "make_all_thumbs_jpg", 0))) {
       return $base . $cache_buster;
     } else if ($this->is_album()) {
       return $base . "/.album.jpg" . $cache_buster;
-    } else if ($this->is_movie()) {
-      // Replace the extension with jpg
+    } else {
+      // Replace the extension with jpg for non-jpg photos if make_all_thumbs_jpg set and all movies
       $base = legal_file::change_extension($base, "jpg");
       return $base . $cache_buster;
     }
@@ -223,8 +225,16 @@ class Item_Model_Core extends ORM_MPTT {
    * photo: /var/albums/album1/photo.resize.jpg
    */
   public function resize_path() {
-    return VARPATH . "resizes/" . urldecode($this->relative_path()) .
-      ($this->is_album() ? "/.album.jpg" : "");
+    $base = VARPATH . "resizes/" . urldecode($this->relative_path());
+    if ($this->is_photo() && ($this->mime_type == "image/jpeg" ||
+        !module::get_var("gallery", "make_all_resizes_jpg", 0))) {
+      return $base;
+    } else if ($this->is_album()) {
+      return $base . "/.album.jpg";
+    } else {
+      // Replace the extension with jpg for non-jpg photos if make_all_thumbs_jpg set and all movies
+      return legal_file::change_extension($base, "jpg");
+    }
   }
 
   /**
@@ -232,10 +242,19 @@ class Item_Model_Core extends ORM_MPTT {
    * photo: http://example.com/gallery3/var/albums/album1/photo.resize.jpg
    */
   public function resize_url($full_uri=false) {
-    $relative_path = "var/resizes/" . $this->relative_path();
     $cache_buster = $this->_cache_buster($this->resize_path());
-    return ($full_uri ? url::abs_file($relative_path) : url::file($relative_path)) .
-      ($this->is_album() ? "/.album.jpg" : "") . $cache_buster;
+    $relative_path = "var/resizes/" . $this->relative_path();
+    $base = ($full_uri ? url::abs_file($relative_path) : url::file($relative_path));
+    if ($this->is_photo() && ($this->mime_type == "image/jpeg" ||
+        !module::get_var("gallery", "make_all_resizes_jpg", 0))) {
+      return $base . $cache_buster;
+    } else if ($this->is_album()) {
+      return $base . "/.album.jpg" . $cache_buster;
+    } else {
+      // Replace the extension with jpg for non-jpg photos if make_all_thumbs_jpg set and all movies
+      $base = legal_file::change_extension($base, "jpg");
+      return $base . $cache_buster;
+    }
   }
 
   /**

--- a/modules/gallery/module.info
+++ b/modules/gallery/module.info
@@ -1,6 +1,6 @@
 name = "Gallery 3"
 description = "Gallery core application"
-version = 55
+version = 56
 author_name = "Gallery Team"
 author_url = "http://codex.galleryproject.org/Gallery:Team"
 info_url = "http://codex.galleryproject.org/Gallery3:Modules:gallery"

--- a/modules/gallery/views/admin_graphics.html.php
+++ b/modules/gallery/views/admin_graphics.html.php
@@ -36,5 +36,22 @@
       <? endforeach ?>
     </div>
   </div>
-</div>
 
+  <div id="g-admin-graphics-settings" class="g-block ui-helper-clearfix">
+    <h2> <?= t("Other settings") ?> </h2>
+    <p>
+      <?= t("By default, Gallery preserves formats when generating resize and thumbnail images.") ?>
+      <?= t("This means that a PNG full-size image will have PNG resize and thumbnail images.") ?>
+    </p>
+    <p>
+      <?= t("Alternatively, Gallery can make all resize or thumbnail images JPG.") ?>
+      <?= t("These can be much smaller: for example, a typical photographic JPG is 5-10x smaller than a PNG.") ?>
+      <?= t("This reduces page load time while still preserving the full-size image in its original format.") ?>
+    </p>
+    <p>
+      <?= t("Changing these settings will temporarily put the site into maintenance mode (if not already in maintenance mode).") ?>
+      <?= t("Once finished, it will return maintenance mode to its original state and mark all affected images for rebuild.") ?>
+    </p>
+    <?= $form ?>
+  </div>
+</div>


### PR DESCRIPTION
- Added make_all_resizes_jpg and make_all_thumbs_jpg Gallery variables.
- Updated gallery_installer, module.info, and install.sql to v56 to add them
- Revised Item_Model functions that return thumb/resize paths and urls.
- Changed item::find_by_path to add type argument and accomodate new options.
- Changed file_proxy to use new item::find_by_path.
- Updated file_proxy and data_rest to return the correct mime types.
- Included functions in graphics helper to enable/disable the new options.
- Added unit tests (NOT FINISHED).
