### PR TITLE
Follow-on to 5fca371a616dba16f955087c4477ee229ee222d0 for #1945.

### DIFF
--- a/modules/watermark/controllers/admin_watermarks.php
+++ b/modules/watermark/controllers/admin_watermarks.php
@@ -104,7 +104,7 @@ class Admin_Watermarks_Controller extends Admin_Controller {
 
       list ($width, $height, $mime_type, $extension) = photo::get_file_metadata($file);
       if (!$width || !$height || !$mime_type || !$extension ||
-          !in_array($extension, legal_file::get_photo_extensions())) {
+          !legal_file::get_photo_extensions($extension)) {
         message::error(t("Invalid or unidentifiable image file"));
         @unlink($file);
         return;


### PR DESCRIPTION
Previously skipped admin_watermarks mods to use new functionality of #1945
since there was concurrent work on it with #1970.
Now that both are done, we can wrap this up.
