### PR TITLE
#1988 - Add movie_allow_uploads option ("always", "never", or "autodetect").

### DIFF
--- a/installer/install.sql
+++ b/installer/install.sql
@@ -245,7 +245,7 @@ CREATE TABLE {modules} (
   KEY `weight` (`weight`)
 ) AUTO_INCREMENT=10 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
-INSERT INTO {modules} VALUES (1,1,'gallery',55,1);
+INSERT INTO {modules} VALUES (1,1,'gallery',56,1);
 INSERT INTO {modules} VALUES (2,1,'user',4,2);
 INSERT INTO {modules} VALUES (3,1,'comment',7,3);
 INSERT INTO {modules} VALUES (4,1,'organize',4,4);
@@ -383,7 +383,7 @@ CREATE TABLE {vars} (
   `value` text,
   PRIMARY KEY (`id`),
   UNIQUE KEY `module_name` (`module_name`,`name`)
-) AUTO_INCREMENT=46 DEFAULT CHARSET=utf8;
+) AUTO_INCREMENT=47 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 INSERT INTO {vars} VALUES (NULL,'gallery','active_site_theme','wind');
 INSERT INTO {vars} VALUES (NULL,'gallery','active_admin_theme','admin_wind');
@@ -417,6 +417,7 @@ INSERT INTO {vars} VALUES (NULL,'gallery','extra_binary_paths','/usr/local/bin:/
 INSERT INTO {vars} VALUES (NULL,'gallery','timezone',NULL);
 INSERT INTO {vars} VALUES (NULL,'gallery','lock_timeout','1');
 INSERT INTO {vars} VALUES (NULL,'gallery','movie_extract_frame_time','3');
+INSERT INTO {vars} VALUES (NULL,'gallery','movie_allow_uploads','autodetect');
 INSERT INTO {vars} VALUES (NULL,'gallery','blocks_site_sidebar','a:4:{i:10;a:2:{i:0;s:7:\"gallery\";i:1;s:8:\"language\";}i:11;a:2:{i:0;s:4:\"info\";i:1;s:8:\"metadata\";}i:12;a:2:{i:0;s:3:\"rss\";i:1;s:9:\"rss_feeds\";}i:13;a:2:{i:0;s:3:\"tag\";i:1;s:3:\"tag\";}}');
 INSERT INTO {vars} VALUES (NULL,'gallery','identity_provider','user');
 INSERT INTO {vars} VALUES (NULL,'user','minimum_password_length','5');

--- a/modules/gallery/helpers/gallery_installer.php
+++ b/modules/gallery/helpers/gallery_installer.php
@@ -315,6 +315,7 @@ class gallery_installer {
     module::set_var("gallery", "timezone", null);
     module::set_var("gallery", "lock_timeout", 1);
     module::set_var("gallery", "movie_extract_frame_time", 3);
+    module::set_var("gallery", "movie_allow_uploads", "autodetect");
   }
 
   static function upgrade($version) {
@@ -789,6 +790,13 @@ class gallery_installer {
       module::set_version("gallery", $version = 55);
     }
 
+    if ($version == 55) {
+      // In v56, we added the ability to change the default behavior regarding movie uploads.  It
+      // can be set to "always", "never", or "autodetect" to match the previous behavior where they
+      // are allowed only if FFmpeg is found.
+      module::set_var("gallery", "movie_allow_uploads", "autodetect");
+      module::set_version("gallery", $version = 56);
+    }
   }
 
   static function uninstall() {

--- a/modules/gallery/helpers/legal_file.php
+++ b/modules/gallery/helpers/legal_file.php
@@ -98,7 +98,7 @@ class legal_file_Core {
    */
   static function get_types_by_extension($extension=null) {
     $types_by_extension = legal_file::get_photo_types_by_extension();
-    if (movie::find_ffmpeg()) {
+    if (movie::allow_uploads()) {
       $types_by_extension = array_merge($types_by_extension,
                                         legal_file::get_movie_types_by_extension());
     }
@@ -165,7 +165,7 @@ class legal_file_Core {
    */
   static function get_extensions($extension=null) {
     $extensions = legal_file::get_photo_extensions();
-    if (movie::find_ffmpeg()) {
+    if (movie::allow_uploads()) {
       $extensions = array_merge($extensions, legal_file::get_movie_extensions());
     }
     if ($extension) {

--- a/modules/gallery/helpers/movie.php
+++ b/modules/gallery/helpers/movie.php
@@ -24,6 +24,8 @@
  * Note: by design, this class does not do any permission checking.
  */
 class movie_Core {
+  private static $allow_uploads;
+
   static function get_edit_form($movie) {
     $form = new Forge("movies/update/$movie->id", "", "post", array("id" => "g-edit-movie-form"));
     $form->hidden("from_id")->value($movie->id);
@@ -107,6 +109,29 @@ class movie_Core {
         throw new Exception("@todo FFMPEG_FAILED");
       }
     }
+  }
+
+  /**
+   * Return true if movie uploads are allowed, false if not.  This is based on the
+   * "movie_allow_uploads" Gallery variable as well as whether or not ffmpeg is found.
+   */
+  static function allow_uploads() {
+    if (empty(self::$allow_uploads)) {
+      // Refresh ffmpeg settings
+      $ffmpeg = movie::find_ffmpeg();
+      switch (module::get_var("gallery", "movie_allow_uploads", "autodetect")) {
+        case "always":
+          self::$allow_uploads = true;
+          break;
+        case "never":
+          self::$allow_uploads = false;
+          break;
+        default:
+          self::$allow_uploads = !empty($ffmpeg);
+          break;
+      }
+    }
+    return self::$allow_uploads;
   }
 
   /**

--- a/modules/gallery/libraries/Form_Uploadify.php
+++ b/modules/gallery/libraries/Form_Uploadify.php
@@ -46,7 +46,7 @@ class Form_Uploadify_Core extends Form_Input {
     $v->album = $this->data["album"];
     $v->script_data = $this->data["script_data"];
     $v->simultaneous_upload_limit = module::get_var("gallery", "simultaneous_upload_limit");
-    $v->movies_allowed = (bool) movie::find_ffmpeg();
+    $v->movies_allowed = movie::allow_uploads();
     $v->extensions = legal_file::get_filters();
     $v->suhosin_session_encrypt = (bool) ini_get("suhosin.session.encrypt");
 

--- a/modules/gallery/module.info
+++ b/modules/gallery/module.info
@@ -1,6 +1,6 @@
 name = "Gallery 3"
 description = "Gallery core application"
-version = 55
+version = 56
 author_name = "Gallery Team"
 author_url = "http://codex.galleryproject.org/Gallery:Team"
 info_url = "http://codex.galleryproject.org/Gallery3:Modules:gallery"


### PR DESCRIPTION
- gallery_installer, module.info, install.sql - add movie_allow_uploads variable
- movie::allow_uploads (new) - return true if allow_movie_uploads is "always" or "autodetect" and FFmpeg found, false otherwise
- legal_file - use movie::allow_uploads instead of movie::find_ffmpeg
- Form_Uploadify - use movie::allow_uploads instead of movie::find_ffmpeg
