### PR TITLE
Follow-on to 212944e1eae2ffb9a3e27ea7d1c6813160cce1ed for #1951.

### DIFF
--- a/modules/gallery/helpers/movie.php
+++ b/modules/gallery/helpers/movie.php
@@ -192,10 +192,19 @@ class movie_Core {
       $metadata->extension = strtolower($extension);
     }
 
-    // Run movie_get_file_metadata events which can modify the class, then return results.
+    // Run movie_get_file_metadata events which can modify the class.
     module::event("movie_get_file_metadata", $file_path, $metadata);
-    return array($metadata->width, $metadata->height, $metadata->mime_type,
-                 $metadata->extension, $metadata->duration);
+
+    // Check that the post-events results are valid, then return them.  Note that, unlike photos,
+    // having zero width and height isn't considered invalid (as is the case when FFmpeg isn't
+    // installed).
+    if ($metadata->mime_type && $metadata->extension &&
+        ($metadata->mime_type == legal_file::get_movie_types_by_extension($metadata->extension))) {
+      return array($metadata->width, $metadata->height, $metadata->mime_type,
+                   $metadata->extension, $metadata->duration);
+    } else {
+      return array(0, 0, null, null, 0);
+    }
   }
 
   /**

--- a/modules/gallery/helpers/photo.php
+++ b/modules/gallery/helpers/photo.php
@@ -133,8 +133,15 @@ class photo_Core {
       $metadata->height = 0;
     }
 
-    // Run photo_get_file_metadata events which can modify the class, then return results.
+    // Run photo_get_file_metadata events which can modify the class.
     module::event("photo_get_file_metadata", $file_path, $metadata);
-    return array($metadata->width, $metadata->height, $metadata->mime_type, $metadata->extension);
+
+    // Check that the post-events results are valid, then return them.
+    if ($metadata->width && $metadata->height && $metadata->mime_type && $metadata->extension &&
+        ($metadata->mime_type == legal_file::get_photo_types_by_extension($metadata->extension))) {
+      return array($metadata->width, $metadata->height, $metadata->mime_type, $metadata->extension);
+    } else {
+      return array(0, 0, null, null);
+    }
   }
 }

--- a/modules/gallery/tests/Movie_Helper_Test.php
+++ b/modules/gallery/tests/Movie_Helper_Test.php
@@ -64,7 +64,8 @@ class Movie_Helper_Test extends Gallery_Unit_Test_Case {
 
   public function get_file_metadata_with_no_extension_test() {
     copy(MODPATH . "gallery/tests/test.flv", TMPPATH . "test_flv_with_no_extension");
-    $this->assert_equal(array(360, 288, null, null, 6.00),
+    // Since mime type and extension are based solely on the filename, this is considered invalid.
+    $this->assert_equal(array(0, 0, null, null, 0),
                         movie::get_file_metadata(TMPPATH . "test_flv_with_no_extension"));
   }
 
@@ -75,7 +76,18 @@ class Movie_Helper_Test extends Gallery_Unit_Test_Case {
 
   public function get_file_metadata_with_illegal_extension_but_valid_file_contents_test() {
     copy(MODPATH . "gallery/tests/test.flv", TMPPATH . "test_flv_with_php_extension.php");
-    $this->assert_equal(array(360, 288, null, null, 6.00),
+    // Since mime type and extension are based solely on the filename, this is considered invalid.
+    $this->assert_equal(array(0, 0, null, null, 0),
                         movie::get_file_metadata(TMPPATH . "test_flv_with_php_extension.php"));
+  }
+
+  public function get_file_metadata_with_valid_extension_but_illegal_file_contents_test() {
+    copy(MODPATH . "gallery/tests/Photo_Helper_Test.php", TMPPATH . "test_php_with_flv_extension.flv");
+    // Since mime type and extension are based solely on the filename, this is considered valid.
+    // Of course, FFmpeg cannot extract width, height, or duration from the file.  Note that this
+    // isn't a really a security problem, since the filename doesn't have a php extension and
+    // therefore will never be executed.
+    $this->assert_equal(array(0, 0, "video/x-flv", "flv", 0),
+                        movie::get_file_metadata(TMPPATH . "test_php_with_flv_extension.flv"));
   }
 }

--- a/modules/gallery/tests/Photo_Helper_Test.php
+++ b/modules/gallery/tests/Photo_Helper_Test.php
@@ -53,4 +53,10 @@ class Photo_Helper_Test extends Gallery_Unit_Test_Case {
     $this->assert_equal(array(1024, 768, "image/jpeg", "jpg"),
                         photo::get_file_metadata(TMPPATH . "test_jpg_with_php_extension.php"));
   }
+
+  public function get_file_metadata_with_valid_extension_but_illegal_file_contents_test() {
+    copy(MODPATH . "gallery/tests/Photo_Helper_Test.php", TMPPATH . "test_php_with_jpg_extension.jpg");
+    $this->assert_equal(array(0, 0, null, null),
+                        photo::get_file_metadata(TMPPATH . "test_php_with_jpg_extension.jpg"));
+  }
 }


### PR DESCRIPTION
- After events, check that metadata is valid.  If invalid, return empty array.
- Add unit tests to test cases of invalid files with valid extensions.
