### PR TITLE
#1993 - Remove "failed" query string from upgrader redirect if there are no errors.

### DIFF
--- a/modules/gallery/controllers/upgrader.php
+++ b/modules/gallery/controllers/upgrader.php
@@ -107,7 +107,11 @@ class Upgrader_Controller extends Controller {
         print "Upgrade complete\n";
       }
     } else {
-      url::redirect("upgrader?failed=" . join(",", $failed));
+      if ($failed) {
+        url::redirect("upgrader?failed=" . join(",", $failed));
+      } else {
+        url::redirect("upgrader");
+      }
     }
   }
 }


### PR DESCRIPTION
- Changed redirect if it finished without failures.
- No change to Upgrader_Controller::index(), since its behavior with an empty vs. undefined failed query is identical.

... and saved people like me from being freaked out when they upgrade their 35,000+ image production site to the newest development version only to see "failed" in the address bar :-)
