### PR TITLE
#1749, 1754, 1901 - revert two recent commits that check for Zend Guard code obfuscation.

### DIFF
--- a/index.php
+++ b/index.php
@@ -29,13 +29,6 @@ if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
   exit("Gallery is not supported on Windows (PHP reports that you're using: " . PHP_OS . ")");
 }
 
-// Gallery doesn't use Zend Guard code obfuscation, and Kohana 2.4 will not work if level is 3+.
-if (function_exists("zend_current_obfuscation_level") && (zend_current_obfuscation_level() >= 3)) {
-  exit("Gallery doesn't use Zend Guard code obfuscation, and is incompatible if it's running " .
-       "with a level of 3 or higher.  For Gallery to run, please edit your main php.ini file and " .
-       "change/add the following line: 'zend_loader.obfuscation_level_support = 2'");
-}
-
 // PHP 5.4 requires a timezone - if one isn't set date functions aren't going to work properly.
 // We'll log this once the logging system is initialized (in the gallery_event::gallery_ready).
 if (!ini_get("date.timezone")) {

--- a/installer/installer.php
+++ b/installer/installer.php
@@ -243,11 +243,6 @@ class installer {
       $errors[] = "Gallery cannot function when PHP is in <a href=\"http://php.net/manual/en/features.safe-mode.php\">Safe Mode</a>.  Please disable safe mode.";
     }
 
-    if (function_exists("zend_current_obfuscation_level") && (zend_current_obfuscation_level() >= 3)) {
-      $errors[] = "Gallery doesn't use <a href=\"http://www.zend.com/en/products/guard\">Zend Guard code obfuscation</a>, and is incompatible if it's running " .
-        "with a level of 3 or higher.  Please edit your main php.ini file and change/add the following line: 'zend_loader.obfuscation_level_support = 2'";
-    }
-
     return @$errors;
   }
 


### PR DESCRIPTION
This is not the root of the problem for all installs, and can trigger false positives
that break previously-working installs... we'll have to find a better way.
