### PR TITLE
#2006 - Add system::mark_file_for_delete API to delete files at shutdown.

### DIFF
--- a/modules/gallery/controllers/quick.php
+++ b/modules/gallery/controllers/quick.php
@@ -41,7 +41,6 @@ class Quick_Controller extends Controller {
       gallery_graphics::rotate($item->file_path(), $tmpfile, array("degrees" => $degrees), $item);
       $item->set_data_file($tmpfile);
       $item->save();
-      unlink($tmpfile);
     }
 
     if (Input::instance()->get("page_type") == "collection") {

--- a/modules/gallery/controllers/uploader.php
+++ b/modules/gallery/controllers/uploader.php
@@ -55,7 +55,7 @@ class Uploader_Controller extends Controller {
 
     if ($form->validate() && $file_validation->validate()) {
       $temp_filename = upload::save("Filedata");
-      Event::add("system.shutdown", create_function("", "unlink(\"$temp_filename\");"));
+      system::delete_later($temp_filename);
       try {
         $item = ORM::factory("item");
         $item->name = substr(basename($temp_filename), 10);  // Skip unique identifier Kohana adds

--- a/modules/gallery/helpers/gallery_event.php
+++ b/modules/gallery/helpers/gallery_event.php
@@ -44,7 +44,7 @@ class gallery_event_Core {
     // var/tmp might be stickier because theoretically we could wind up spamming that
     // dir with a lot of files.  But let's start with this and refine as we go.
     if (!(rand() % 500)) {
-      // Note that this code is roughly duplicated in gallery_event::gallery_shutdown
+      // Note that this code is roughly duplicated in gallery_task::file_cleanup
       $threshold = time() - 1209600; // older than 2 weeks
       foreach(array("logs", "tmp") as $dir) {
         $dir = VARPATH . $dir;
@@ -67,6 +67,8 @@ class gallery_event_Core {
         }
       }
     }
+    // Delete all files marked using system::delete_later.
+    system::delete_marked_files();
   }
 
   static function user_deleted($user) {

--- a/modules/rest/controllers/rest.php
+++ b/modules/rest/controllers/rest.php
@@ -69,7 +69,7 @@ class Rest_Controller extends Controller {
         $request->params = (object) $input->post();
         if (isset($_FILES["file"])) {
           $request->file = upload::save("file");
-          Event::add("system.shutdown", create_function("", "unlink(\"{$request->file}\");"));
+          system::delete_later($request->file);
         }
         break;
       }

--- a/modules/watermark/controllers/admin_watermarks.php
+++ b/modules/watermark/controllers/admin_watermarks.php
@@ -67,7 +67,7 @@ class Admin_Watermarks_Controller extends Admin_Controller {
     $form = watermark::get_delete_form();
     if ($form->validate()) {
       if ($name = basename(module::get_var("watermark", "name"))) {
-        @unlink(VARPATH . "modules/watermark/$name");
+        system::delete_later(VARPATH . "modules/watermark/$name");
 
         module::clear_var("watermark", "name");
         module::clear_var("watermark", "width");
@@ -108,7 +108,7 @@ class Admin_Watermarks_Controller extends Admin_Controller {
         $name = legal_file::sanitize_filename($name, $extension, "photo");
       } catch (Exception $e) {
         message::error(t("Invalid or unidentifiable image file"));
-        @unlink($file);
+        system::delete_later($file);
         return;
       }
 
@@ -120,7 +120,7 @@ class Admin_Watermarks_Controller extends Admin_Controller {
       module::set_var("watermark", "position", $form->add_watermark->position->value);
       module::set_var("watermark", "transparency", $form->add_watermark->transparency->value);
       $this->_update_graphics_rules();
-      @unlink($file);
+      system::delete_later($file);
 
       message::success(t("Watermark saved"));
       log::success("watermark", t("Watermark saved"));


### PR DESCRIPTION
- added system::mark_file_for_delete to be called to mark a file
- added system::delete_marked_files to be called at shutdown to delete the list
- amended system::temp_filename to, by default, add the temp name to the list
- updated a few other places in code where this should be used
