### PR TITLE
Context menus are fixed!

### DIFF
--- a/lib/gallery.common.js
+++ b/lib/gallery.common.js
@@ -137,18 +137,21 @@
         return;
       }
       var list = $(hover_target).find("ul");
+
       hover_target.find("*").removeAttr('title');
+      hover_target.find(".g-dialog-link").gallery_dialog();
+      hover_target.find(".g-ajax-link").gallery_ajax();
       list.hide();
+
       hover_target.hover(
         function() {
           list.stop(true, true).slideDown("fast");
-          $(this).find(".g-dialog-link").gallery_dialog();
-          $(this).find(".g-ajax-link").gallery_ajax();
         },
         function() {
           list.stop(true, true).slideUp("slow");
         }
       );
+
       hover_target.addClass("g-context-menu-initialized");
     }
   };


### PR DESCRIPTION
This should be fully compatible with older themes since only gallery.common.js is modified.

Now that I understand the problem and the fix, I'm not sure I can explain why it
_used_ to work with older jQuery...
