### PR TITLE
#2011 - Add IE version check to new js, re-introduce old-IE shim previously removed.

### DIFF
--- a/lib/gallery.common.js
+++ b/lib/gallery.common.js
@@ -291,4 +291,30 @@
     $(this).autocomplete(autocomplete_options);
   };
 
+  /**
+   * Detect IE version.  This is a pseudo-replacement for the old $.browser function, and can be
+   * useful for CSS tweaks related to specific IE versions.  This uses conditional comments, which
+   * is a more reliable method than user agent sniffing.
+   *
+   * If IE version 5 or newer, return the version number.
+   * If IE verison 4 or older, or not IE, return undefined.
+   *
+   * ex: ($.gallery_ie_version() <= 8) tests for IE v8 and older
+   *
+   * Adopted from http://gist.github.com/padolsey/527683
+   */
+  $.gallery_ie_version = function() {
+    var undef;
+    var v = 3;
+    var div = document.createElement('div');
+    var all = div.getElementsByTagName('i');
+
+    while (
+      div.innerHTML = '<!--[if gt IE ' + (++v) + ']><i></i><![endif]-->',
+      all[0]
+    );
+
+    return v > 4 ? v : undef;
+  };
+
 })(jQuery);

--- a/themes/wind/js/ui.init.js
+++ b/themes/wind/js/ui.init.js
@@ -3,6 +3,7 @@
  */
 
 $(document).ready(function() {
+  var ie_version = $.gallery_ie_version();
 
   // Initialize Superfish menus (hidden, then shown to address IE issue)
   $("#g-site-menu .g-menu").hide().addClass("sf-menu");
@@ -82,12 +83,15 @@ $(document).ready(function() {
         } else {
           var sib_height = $(this).prev().height();
         }
+        if (ie_version <= 8) {
+          sib_height = sib_height + 1;
+        }
         $(this).css("height", sib_height);
         $(this).css("position", "relative");
         $(this).css("top", 0).css("left", 0);
         // Remove the placeholder and hover class from the item
         $(this).removeClass("g-hover-item");
-	$(this).gallery_valign();
+        $(this).gallery_valign();
         $("#g-place-holder").remove();
       }
     );
@@ -95,7 +99,7 @@ $(document).ready(function() {
     // Realign any thumbnails that change so that when we rotate a thumb it stays centered.
     $(".g-item").bind("gallery.change", function() {
       $(".g-item").each(function() {
-	$(this).height($(this).find("img").height() + 2);
+        $(this).height($(this).find("img").height() + 2);
       });
       $(".g-item").equal_heights().gallery_valign();
     });


### PR DESCRIPTION
- added $.gallery_ie_version() to gallery.common.js, which detects IE versions 5 and up.
- used new function to re-introduce the old-IE shim in ui.init.js (previously removed since $.browser is gone).
- reformatted ui.init.js a bit (replaced tabs with spaces).
