### PR TITLE
#2014 - Clean up gallery.ajax.js.

### DIFF
--- a/lib/gallery.ajax.js
+++ b/lib/gallery.ajax.js
@@ -2,10 +2,10 @@
   $.widget("ui.gallery_ajax",  {
     _init: function() {
       this.element.click(function(event) {
-        eval("var ajax_handler = " + $(event.currentTarget).attr("ajax_handler"));
+        eval("var ajax_handler = " + $(event.currentTarget).attr("data-ajax-handler"));
         $.get($(event.currentTarget).attr("href"), function(data) {
           ajax_handler(data);
-	});
+        });
         event.preventDefault();
         return false;
       });

--- a/modules/gallery/views/menu_ajax_link.html.php
+++ b/modules/gallery/views/menu_ajax_link.html.php
@@ -4,7 +4,7 @@
      class="g-ajax-link <?= $menu->css_class ?>"
      href="<?= $menu->url ?>"
      title="<?= $menu->label->for_html_attr() ?>"
-     ajax_handler="<?= $menu->ajax_handler ?>">
+     data-ajax-handler="<?= $menu->ajax_handler ?>">
     <?= $menu->label->for_html() ?>
   </a>
 </li>


### PR DESCRIPTION
- prepend "data-" in front of non-standard attr to be more standards compliant.
- fix formatting.
