### PR TITLE
#2021 - Cleanup thumb_dirty and resize_dirty instances.

### DIFF
--- a/installer/install.sql
+++ b/installer/install.sql
@@ -245,7 +245,7 @@ CREATE TABLE {modules} (
   KEY `weight` (`weight`)
 ) AUTO_INCREMENT=10 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
-INSERT INTO {modules} VALUES (1,1,'gallery',56,1);
+INSERT INTO {modules} VALUES (1,1,'gallery',57,1);
 INSERT INTO {modules} VALUES (2,1,'user',4,2);
 INSERT INTO {modules} VALUES (3,1,'comment',7,3);
 INSERT INTO {modules} VALUES (4,1,'organize',4,4);

--- a/modules/g2_import/helpers/g2_import.php
+++ b/modules/g2_import/helpers/g2_import.php
@@ -1055,7 +1055,7 @@ class g2_import_Core {
           if (@copy(g2($derivative->fetchPath()), $item->thumb_path())) {
             $item->thumb_height = $derivative->getHeight();
             $item->thumb_width = $derivative->getWidth();
-            $item->thumb_dirty = false;
+            $item->thumb_dirty = 0;
           }
         }
 
@@ -1066,7 +1066,7 @@ class g2_import_Core {
           if (@copy(g2($derivative->fetchPath()), $item->resize_path())) {
             $item->resize_height = $derivative->getHeight();
             $item->resize_width = $derivative->getWidth();
-            $item->resize_dirty = false;
+            $item->resize_dirty = 0;
           }
         }
       }

--- a/modules/gallery/controllers/admin_theme_options.php
+++ b/modules/gallery/controllers/admin_theme_options.php
@@ -34,7 +34,6 @@ class Admin_Theme_Options_Controller extends Admin_Controller {
       module::set_var("gallery", "page_size", $form->edit_theme->page_size->value);
 
       $thumb_size = $form->edit_theme->thumb_size->value;
-      $thumb_dirty = false;
       if (module::get_var("gallery", "thumb_size") != $thumb_size) {
         graphics::remove_rule("gallery", "thumb", "gallery_graphics::resize");
         graphics::add_rule(
@@ -45,7 +44,6 @@ class Admin_Theme_Options_Controller extends Admin_Controller {
       }
 
       $resize_size = $form->edit_theme->resize_size->value;
-      $resize_dirty = false;
       if (module::get_var("gallery", "resize_size") != $resize_size) {
         graphics::remove_rule("gallery", "resize", "gallery_graphics::resize");
         graphics::add_rule(

--- a/modules/gallery/helpers/gallery_installer.php
+++ b/modules/gallery/helpers/gallery_installer.php
@@ -797,6 +797,18 @@ class gallery_installer {
       module::set_var("gallery", "movie_allow_uploads", "autodetect");
       module::set_version("gallery", $version = 56);
     }
+
+    if ($version == 56) {
+      // Cleanup possible instances where resize_dirty of albums or movies was set to 0.  This is
+      // unlikely to have occurred, and doesn't currently matter much since albums and movies don't
+      // have resize images anyway.  However, it may be useful to be consistent here going forward.
+      db::build()
+        ->update("items")
+        ->set("resize_dirty", 1)
+        ->where("type", "<>", "photo")
+        ->execute();
+      module::set_version("gallery", $version = 57);
+    }
   }
 
   static function uninstall() {

--- a/modules/gallery/helpers/graphics.php
+++ b/modules/gallery/helpers/graphics.php
@@ -121,12 +121,6 @@ class graphics_Core {
     if ($item->resize_dirty && $item->is_photo()) {
       $ops["resize"] = $item->resize_path();
     }
-    if (empty($ops)) {
-      $item->thumb_dirty = 0;
-      $item->resize_dirty = 0;
-      $item->save();
-      return;
-    }
 
     try {
       foreach ($ops as $target => $output_file) {

--- a/modules/gallery/module.info
+++ b/modules/gallery/module.info
@@ -1,6 +1,6 @@
 name = "Gallery 3"
 description = "Gallery core application"
-version = 56
+version = 57
 author_name = "Gallery Team"
 author_url = "http://codex.galleryproject.org/Gallery:Team"
 info_url = "http://codex.galleryproject.org/Gallery3:Modules:gallery"


### PR DESCRIPTION
- g2_import: changed "false" assignment to "0" assignment for consistency.
- admin_theme_options: removed unused variables (they're called/used nowhere else).
- graphics: removed stanza that clears thumb_dirty and resize_dirty and returns
  if we have no ops.  This has no effect on Gallery currently (for one,
  graphics::generate doesn't normally get called on an item with no dirty flags),
  but can inconsistently set resize_dirty of albums and movies to 0 where it's
  otherwise left at 1.  Going forward, it may be useful to be consistent here.
- gallery_installer: added v57 stanza to correct any resize_dirty flags of
  movies/albums that were previously reset to 0.
- module.info, install.sql: update to v57
