### PR TITLE
#2032 - Fix short form submit/cancel button formatting.

### DIFF
--- a/lib/gallery.common.js
+++ b/lib/gallery.common.js
@@ -202,6 +202,9 @@
         $(".g-short-form input[type=submit]").addClass("ui-state-default ui-corner-right");
       }
 
+      // Add the hover effect to the buttons
+      $.fn.gallery_hover_init();
+
       // Set the input value equal to label text
       if (input.val() == "") {
         input.val(label.html());

--- a/modules/gallery/views/in_place_edit.html.php
+++ b/modules/gallery/views/in_place_edit.html.php
@@ -8,7 +8,7 @@
     <li>
       <?= form::submit(array("class" => "submit ui-state-default"), t("Save")) ?>
     </li>
-    <li><a href="#" class="g-cancel"><?= t("Cancel") ?></a></li>
+    <li><button class="g-cancel ui-state-default ui-corner-all"><?= t("Cancel") ?></button></li>
     <? if (!empty($errors["input"])): ?>
     <li>
       <p id="g-in-place-edit-message" class="g-error"><?= $errors["input"] ?></p>

--- a/themes/admin_wind/css/screen.css
+++ b/themes/admin_wind/css/screen.css
@@ -255,6 +255,10 @@ input[readonly] {
   width: 100%;
 }
 
+.g-short-form .submit {
+  padding: .3em .6em;
+}
+
 .g-short-form .textbox.g-error {
   border: 1px solid #f00;
   color: #f00;
@@ -263,7 +267,8 @@ input[readonly] {
 
 .g-short-form .g-cancel {
   display: block;
-  margin: .3em .8em;
+  margin: 0em .8em;
+  padding: .3em .6em;
 }
 
 #g-sidebar .g-short-form li {

--- a/themes/wind/css/screen.css
+++ b/themes/wind/css/screen.css
@@ -276,6 +276,10 @@ input[readonly] {
   width: 100%;
 }
 
+.g-short-form .submit {
+  padding: .3em .6em;
+}
+
 .g-short-form .textbox.g-error {
   border: 1px solid #f00;
   color: #f00;
@@ -284,7 +288,8 @@ input[readonly] {
 
 .g-short-form .g-cancel {
   display: block;
-  margin: .3em .8em;
+  margin: 0em .8em;
+  padding: .3em .6em;
 }
 
 #g-sidebar .g-short-form li {


### PR DESCRIPTION
- fixed the height of the submit buttons to match the input box
- changed the cancel links into cancel buttons
- added the hover effect to the buttons when used in in_place_edit (e.g. admin/tags)
