### PR TITLE
#2034 - Add webm and ogv as valid movie types.

### DIFF
--- a/modules/gallery/helpers/legal_file.php
+++ b/modules/gallery/helpers/legal_file.php
@@ -70,7 +70,8 @@ class legal_file_Core {
     if (empty(self::$movie_types_by_extension)) {
       $types_by_extension_wrapper = new stdClass();
       $types_by_extension_wrapper->types_by_extension = array(
-        "flv" => "video/x-flv", "mp4" => "video/mp4", "m4v" => "video/x-m4v");
+        "flv" => "video/x-flv", "mp4" => "video/mp4", "m4v" => "video/x-m4v",
+        "webm" => "video/webm", "ogv" => "video/ogg");
       module::event("movie_types_by_extension", $types_by_extension_wrapper);
       foreach (self::$blacklist as $key) {
         unset($types_by_extension_wrapper->types_by_extension[$key]);

--- a/modules/gallery/tests/Legal_File_Helper_Test.php
+++ b/modules/gallery/tests/Legal_File_Helper_Test.php
@@ -37,7 +37,7 @@ class Legal_File_Helper_Test extends Gallery_Unit_Test_Case {
     $this->assert_equal(null, legal_file::get_movie_types_by_extension("php.flv")); // invalid w/ .
 
     // No extension returns full array
-    $this->assert_equal(3, count(legal_file::get_movie_types_by_extension()));
+    $this->assert_equal(5, count(legal_file::get_movie_types_by_extension()));
   }
 
   public function get_types_by_extension_test() {
@@ -47,7 +47,7 @@ class Legal_File_Helper_Test extends Gallery_Unit_Test_Case {
     $this->assert_equal(null, legal_file::get_types_by_extension("php.flv"));      // invalid w/ .
 
     // No extension returns full array
-    $this->assert_equal(7, count(legal_file::get_types_by_extension()));
+    $this->assert_equal(9, count(legal_file::get_types_by_extension()));
   }
 
   public function get_photo_extensions_test() {
@@ -69,7 +69,7 @@ class Legal_File_Helper_Test extends Gallery_Unit_Test_Case {
     $this->assert_equal(false, legal_file::get_movie_extensions("php.jpg")); // invalid w/ .
 
     // No extension returns full array
-    $this->assert_equal(3, count(legal_file::get_movie_extensions()));
+    $this->assert_equal(5, count(legal_file::get_movie_extensions()));
   }
 
   public function get_extensions_test() {
@@ -79,12 +79,12 @@ class Legal_File_Helper_Test extends Gallery_Unit_Test_Case {
     $this->assert_equal(false, legal_file::get_extensions("php.jpg")); // invalid w/ .
 
     // No extension returns full array
-    $this->assert_equal(7, count(legal_file::get_extensions()));
+    $this->assert_equal(9, count(legal_file::get_extensions()));
   }
 
   public function get_filters_test() {
-    // All 7 extensions both uppercase and lowercase
-    $this->assert_equal(14, count(legal_file::get_filters()));
+    // All 9 extensions both uppercase and lowercase
+    $this->assert_equal(18, count(legal_file::get_filters()));
   }
 
   public function get_photo_types_test() {
@@ -94,7 +94,7 @@ class Legal_File_Helper_Test extends Gallery_Unit_Test_Case {
 
   public function get_movie_types_test() {
     // Note that this is one *more* than movie extensions since video/flv is added.
-    $this->assert_equal(4, count(legal_file::get_movie_types()));
+    $this->assert_equal(6, count(legal_file::get_movie_types()));
   }
 
   public function change_extension_test() {


### PR DESCRIPTION
- added them to legal_file helper
- revised unit tests

Until we hook up the HTML5 movie player the user will just get a download link, but that's coming up soon.
