### PR TITLE
Provide a Vagrant development environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,30 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant::Config.run do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "gallery3dev"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  # config.vm.box_url = "http://domain.com/path/to/above.box"
+
+  # Assign this VM to a host-only network IP, allowing you to access it
+  # via the IP. Host-only networks can talk to the host machine as well as
+  # any other machines on the same network, but cannot be accessed (through this
+  # network interface) by any external networks.
+  # config.vm.network :hostonly, "192.168.33.30"
+
+  # Assign this VM to a bridged network, allowing you to connect directly to a
+  # network using the host's network device. This makes the VM appear as another
+  # physical device on your network.
+  # config.vm.network :bridged
+
+  # Forward a port from the guest to the host, which allows for outside
+  # computers to access the VM, whereas host only networking does not.
+  # config.vm.forward_port 80, 8080
+end


### PR DESCRIPTION
Hey Bharat,

Is there any interest in providing the Gallery community a preconfigured
Vagrant box to make it easier for people to start hacking?

If so, I'll be happy to do what it takes to make this part of the Gallery
infrastructure (e.g. update documentation, build scripts, etc.) and also to
maintain it.

The VM has been created from a Debian 6.0.6 netinst image using this Chef
cookbook:

https://github.com/jozefs/gallery3-cookbook

The cookbook would probably need to be put among the official Gallery
repositories and we'd need to find some space to host the VM (it's currently
hosted on my Google Drive as a proof-of-concept).

As I was unable to figure out how to get a direct download URL from Google
Drive, to test it out, you'll need to manually save the following somewhere on
you computer:

https://docs.google.com/file/d/0B_n9-qOdaaOLLW5GR2tZenlGWVU/edit?usp=sharing

Then import it to Vagrant:

```
 $ vagrant box add 'gallery3dev' /path/to/downloaded/gallery3dev.box
```

Of course, Vagrant and VirtualBox also need to be installed. After this, just
follow the instructions from the commit message.

The cool thing is that this should work across Linux, Mac and Windows.

  Jozef
