### PR TITLE
#2039 - Make admin/tags capital letter encoding more robust.

### DIFF
--- a/modules/tag/views/admin_tags.html.php
+++ b/modules/tag/views/admin_tags.html.php
@@ -26,7 +26,7 @@
       <tr>
         <td>
         <? foreach ($tags as $i => $tag): ?>
-          <? $current_letter = strtoupper(mb_substr($tag->name, 0, 1)) ?>
+          <? $current_letter = mb_strtoupper(mb_substr($tag->name, 0, 1)) ?>
 
           <? if ($i == 0): /* first letter */ ?>
           <strong><?= html::clean($current_letter) ?></strong>


### PR DESCRIPTION
- change strtoupper() to mb_strtoupper().
  For some locale settings, strtoupper() may not correctly capitalize the letters.
  The cause of this is probably related to the comments in Gallery_I18n.php, where
  it intentionally sets LC_CTYPE to 'C' for some cases.  Whatever the reason, the
  solution is simple and insensitive to what the locale settings are.
