### PR TITLE
Follow-on to #2033 - Change variables and js script loading for Flash Fl...

### DIFF
--- a/modules/gallery/models/item.php
+++ b/modules/gallery/models/item.php
@@ -762,15 +762,15 @@ class Item_Model_Core extends ORM_MPTT {
     //  - generate a view, which is used in place of the standard Flowplayer v3 player
     //    (use view variable)
     //  - alter the arguments sent to the standard player
-    //    (use fp_params and fp_config variables)
+    //    (use fp_flash_params and fp_flash_config variables)
     $movie_img = new stdClass();
     $movie_img->max_size = $max_size;
     $movie_img->width = $width;
     $movie_img->height = $height;
     $movie_img->attrs = $attrs;
     $movie_img->url = $this->file_url(true);
-    $movie_img->fp_params = array(); // additional Flowplayer params values (will be json encoded)
-    $movie_img->fp_config = array(); // additional Flowplayer config values (will be json encoded)
+    $movie_img->fp_flash_params = array(); // add'l Flowplayer params values (will be json encoded)
+    $movie_img->fp_flash_config = array(); // add'l Flowplayer config values (will be json encoded)
     $movie_img->view = array();
     module::event("movie_img", $movie_img, $this);
 
@@ -790,8 +790,8 @@ class Item_Model_Core extends ORM_MPTT {
         $view->height = $movie_img->height;
         $view->attrs = $movie_img->attrs;
         $view->url = $movie_img->url;
-        $view->fp_params = $movie_img->fp_params;
-        $view->fp_config = $movie_img->fp_config;
+        $view->fp_flash_params = $movie_img->fp_flash_params;
+        $view->fp_flash_config = $movie_img->fp_flash_config;
       } else {
         // Filetype NOT supported by Flowplayer v3 - display download link
         $attrs = array_merge($attrs, array("style" => "width: {$max_size}px;",

--- a/modules/gallery/views/movieplayer-flash.html.php
+++ b/modules/gallery/views/movieplayer-flash.html.php
@@ -1,4 +1,5 @@
 <?php defined("SYSPATH") or die("No direct script access.") ?>
+<script type="text/javascript" src="<?= url::file("lib/flowplayer-flash/flowplayer.js") ?>"></script>
 <?= html::anchor($url, "", $attrs) ?>
 <script type="text/javascript">
   var id = "<?= $attrs["id"] ?>";
@@ -23,7 +24,7 @@
       "src": "<?= url::abs_file("lib/flowplayer-flash/flowplayer.swf") ?>",
       "wmode": "transparent",
       "provider": "pseudostreaming"
-    }, <?= json_encode($fp_params) ?>),
+    }, <?= json_encode($fp_flash_params) ?>),
     $.extend(true, {
       "plugins": {
         "pseudostreaming": {
@@ -42,7 +43,7 @@
           set_movie_size(parseInt(clip.metaData.width), parseInt(clip.metaData.height));
         }
       }
-    }, <?= json_encode($fp_config) ?>)
+    }, <?= json_encode($fp_flash_config) ?>)
   ).ipad();
   // set movie size using width and height passed from movie_img function
   $("document").ready(set_movie_size(<?= $width ?>, <?= $height ?>));

--- a/themes/wind/views/page.html.php
+++ b/themes/wind/views/page.html.php
@@ -50,14 +50,8 @@
     <?= $theme->script("gallery.dialog.js") ?>
     <?= $theme->script("superfish/js/superfish.js") ?>
     <?= $theme->script("jquery.localscroll.js") ?>
-
-    <? /* These are page specific but they get combined */ ?>
-    <? if ($theme->page_subtype == "photo"): ?>
     <?= $theme->script("jquery.scrollTo.js") ?>
     <?= $theme->script("gallery.show_full_size.js") ?>
-    <? elseif ($theme->page_subtype == "movie"): ?>
-    <?= $theme->script("flowplayer-flash/flowplayer.js") ?>
-    <? endif ?>
 
     <?= $theme->head() ?>
 


### PR DESCRIPTION
...owplayer.
- changed movie_img event variable names to have "flash" in them.
- moved flowplayer.js loading from page.html.php to movieplayer-flash.
- removed conditional loading for small, photo-specific JS files in page.html.php
  to keep combined JS consistent between page types (better for caching).
