### PR TITLE
Convert README to Markdown and show build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Gallery 3.0+ (development version)
 ==================================
 
+[![Build Status](https://travis-ci.org/gallery/gallery3.png?branch=master)](https://travis-ci.org/gallery/gallery3)
+
 About
 -----
 


### PR DESCRIPTION
Here's how Github renders the README after the change:
