### PR TITLE
Follow-on to #1821 - Remove log entry for closing buffer (can fill logs with "error: 1")

### DIFF
--- a/modules/gallery/controllers/file_proxy.php
+++ b/modules/gallery/controllers/file_proxy.php
@@ -146,7 +146,6 @@ class File_Proxy_Controller extends Controller {
       // going to buffer up whatever file we're proxying (and it may be very large).  This may
       // affect embedding or systems with PHP's output_buffering enabled.
       while (ob_get_level()) {
-        Kohana_Log::add("error","".print_r(ob_get_level(),1));
         if (!@ob_end_clean()) {
           // ob_end_clean() can return false if the buffer can't be removed for some reason
           // (zlib output compression buffers sometimes cause problems).


### PR DESCRIPTION
Probably should cherry-pick back to 3.0.x as well...
