### PR TITLE
Follow-on to #1935 - Ensure ffmpeg is executable, remove possible doubled "/"

### DIFF
--- a/modules/gallery/helpers/movie.php
+++ b/modules/gallery/helpers/movie.php
@@ -138,7 +138,8 @@ class movie_Core {
    * Return the path to the ffmpeg binary if one exists and is executable, or null.
    */
   static function find_ffmpeg() {
-    if (!($ffmpeg_path = module::get_var("gallery", "ffmpeg_path")) || !file_exists($ffmpeg_path)) {
+    if (!($ffmpeg_path = module::get_var("gallery", "ffmpeg_path")) ||
+        !@is_executable($ffmpeg_path)) {
       $ffmpeg_path = system::find_binary(
         "ffmpeg", module::get_var("gallery", "graphics_toolkit_path"));
       module::set_var("gallery", "ffmpeg_path", $ffmpeg_path);

--- a/modules/gallery/helpers/system.php
+++ b/modules/gallery/helpers/system.php
@@ -47,6 +47,7 @@ class system_Core {
       explode(":", module::get_var("gallery", "extra_binary_paths")));
 
     foreach ($paths as $path) {
+      $path = rtrim($path, "/");
       $candidate = "$path/$binary";
       // @suppress errors below to avoid open_basedir issues
       if (@file_exists($candidate)) {


### PR DESCRIPTION
- movie::find_ffmpeg - made it use is_executable instead of just file_exists.
- system::find_binary - removed possible doubled "/" in paths.

If it's not too late, it'd be nice to put this in 3.0.x, too, as I've seen a couple people get confused when we report that it's found but it doesn't work since their host doesn't allow execution of user-uploaded binaries.  It's a nice-to-have, but not a must have.
