### PR TITLE
#2049 - Fix issues with ports other than http/80 or https/443.

### DIFF
--- a/system/helpers/url.php
+++ b/system/helpers/url.php
@@ -62,7 +62,9 @@ class url_Core {
 			if ($site_domain === '' OR $site_domain[0] === '/')
 			{
 				// Guess the server name if the domain starts with slash
-				$base_url = $protocol.'://'.($_SERVER['SERVER_NAME']?$_SERVER['SERVER_NAME']:$_SERVER['HTTP_HOST']).$site_domain;
+				$port = $_SERVER['SERVER_PORT'];
+				$port = ((($port == 80) && ($protocol == 'http')) || (($port == 443) && ($protocol == 'https')) || !$port) ? '' : ":$port";
+				$base_url = $protocol.'://'.($_SERVER['SERVER_NAME']?($_SERVER['SERVER_NAME'].$port):$_SERVER['HTTP_HOST']).$site_domain;
 			}
 			else
 			{


### PR DESCRIPTION
- prefer HTTP_POST over SERVER_NAME for getting the domain name (includes port, handles domain aliases better)
- ensure that HTTP_POST is escaped (avoids possible XSS vulnerability)
