### PR TITLE
#2053 - Change all .bind() to .on() for jQuery future-proofing.

### DIFF
--- a/lib/gallery.common.js
+++ b/lib/gallery.common.js
@@ -212,7 +212,7 @@
       }
 
       // Attach event listeners to the input
-      input.bind("focus", function(e) {
+      input.on("focus", function(e) {
         // Empty input value if it equals it's label
         if ($(this).val() == label.html()) {
           $(this).val("");
@@ -220,7 +220,7 @@
         button.attr("disabled", false);
       });
 
-      input.bind("blur", function(e){
+      input.on("blur", function(e) {
         // Reset the input value if it's empty
         if ($(this).val() == "") {
           $(this).val(label.html());

--- a/modules/server_add/js/server_add.js
+++ b/modules/server_add/js/server_add.js
@@ -33,7 +33,7 @@
        $("#g-server-add-tree span.g-directory", this.element).dblclick(function(event) {
          self.open_dir(event);
        });
-       $("#g-dialog").bind("dialogclose", function(event, ui) {
+       $("#g-dialog").on("dialogclose", function(event, ui) {
          window.location.reload();
        });
      },

--- a/themes/wind/js/ui.init.js
+++ b/themes/wind/js/ui.init.js
@@ -83,7 +83,7 @@ $(document).ready(function() {
     );
 
     // Realign any thumbnails that change so that when we rotate a thumb it stays centered.
-    $(".g-item").bind("gallery.change", function() {
+    $(".g-item").on("gallery.change", function() {
       $(".g-item").each(function() {
         $(this).height($(this).find("img").height() + 2);
       });

--- a/themes/wind/views/photo.html.php
+++ b/themes/wind/views/photo.html.php
@@ -12,7 +12,7 @@
 
     // After the image is rotated or replaced we have to reload the image dimensions
     // so that the full size view isn't distorted.
-    $("#g-photo").bind("gallery.change", function() {
+    $("#g-photo").on("gallery.change", function() {
       $.ajax({
         url: "<?= url::site("items/dimensions/" . $theme->item()->id) ?>",
         dataType: "json",


### PR DESCRIPTION
- on/off are preferred to bind/unbind, live/die, and delegate/undelegate in jQuery 1.7+
- they're likely on the road toward deprecation, so let's replace them now.
