### PR TITLE
#2057 - Revise item name and slug validation - backslashes, refactor, error messages.

### DIFF
--- a/installer/install.sql
+++ b/installer/install.sql
@@ -245,7 +245,7 @@ CREATE TABLE {modules} (
   KEY `weight` (`weight`)
 ) AUTO_INCREMENT=10 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
-INSERT INTO {modules} VALUES (1,1,'gallery',57,1);
+INSERT INTO {modules} VALUES (1,1,'gallery',58,1);
 INSERT INTO {modules} VALUES (2,1,'user',4,2);
 INSERT INTO {modules} VALUES (3,1,'comment',7,3);
 INSERT INTO {modules} VALUES (4,1,'organize',4,4);

--- a/modules/gallery/helpers/album.php
+++ b/modules/gallery/helpers/album.php
@@ -34,11 +34,15 @@ class album_Core {
       ->error_messages("length", t("Your title is too long"));
     $group->textarea("description")->label(t("Description"));
     $group->input("name")->label(t("Directory name"))
-      ->error_messages("no_slashes", t("The directory name can't contain the \"/\" character"))
+      ->error_messages("no_slashes", t("The directory name can't contain a \"/\""))
+      ->error_messages("no_backslashes", t("The directory name can't contain a \"\\\""))
+      ->error_messages("no_trailing_period", t("The directory name can't end in \".\""))
       ->error_messages("required", t("You must provide a directory name"))
       ->error_messages("length", t("Your directory name is too long"))
       ->error_messages("conflict", t("There is already a movie, photo or album with this name"));
     $group->input("slug")->label(t("Internet Address"))
+      ->error_messages(
+        "conflict", t("There is already a movie, photo or album with this internet address"))
       ->error_messages(
         "reserved", t("This address is reserved and can't be used."))
       ->error_messages(
@@ -64,13 +68,14 @@ class album_Core {
     $group = $form->group("edit_item")->label(t("Edit Album"));
 
     $group->input("title")->label(t("Title"))->value($parent->title)
-        ->error_messages("required", t("You must provide a title"))
+      ->error_messages("required", t("You must provide a title"))
       ->error_messages("length", t("Your title is too long"));
     $group->textarea("description")->label(t("Description"))->value($parent->description);
     if ($parent->id != 1) {
       $group->input("name")->label(t("Directory Name"))->value($parent->name)
         ->error_messages("conflict", t("There is already a movie, photo or album with this name"))
         ->error_messages("no_slashes", t("The directory name can't contain a \"/\""))
+        ->error_messages("no_backslashes", t("The directory name can't contain a \"\\\""))
         ->error_messages("no_trailing_period", t("The directory name can't end in \".\""))
         ->error_messages("required", t("You must provide a directory name"))
         ->error_messages("length", t("Your directory name is too long"));

--- a/modules/gallery/helpers/movie.php
+++ b/modules/gallery/helpers/movie.php
@@ -38,6 +38,7 @@ class movie_Core {
       ->error_messages(
         "conflict", t("There is already a movie, photo or album with this name"))
       ->error_messages("no_slashes", t("The movie name can't contain a \"/\""))
+      ->error_messages("no_backslashes", t("The movie name can't contain a \"\\\""))
       ->error_messages("no_trailing_period", t("The movie name can't end in \".\""))
       ->error_messages("illegal_data_file_extension", t("You cannot change the movie file extension"))
       ->error_messages("required", t("You must provide a movie file name"))

--- a/modules/gallery/helpers/photo.php
+++ b/modules/gallery/helpers/photo.php
@@ -35,6 +35,7 @@ class photo_Core {
     $group->input("name")->label(t("Filename"))->value($photo->name)
       ->error_messages("conflict", t("There is already a movie, photo or album with this name"))
       ->error_messages("no_slashes", t("The photo name can't contain a \"/\""))
+      ->error_messages("no_backslashes", t("The photo name can't contain a \"\\\""))
       ->error_messages("no_trailing_period", t("The photo name can't end in \".\""))
       ->error_messages("illegal_data_file_extension", t("You cannot change the photo file extension"))
       ->error_messages("required", t("You must provide a photo file name"))

--- a/modules/gallery/module.info
+++ b/modules/gallery/module.info
@@ -1,6 +1,6 @@
 name = "Gallery 3"
 description = "Gallery core application"
-version = 57
+version = 58
 author_name = "Gallery Team"
 author_url = "http://codex.galleryproject.org/Gallery:Team"
 info_url = "http://codex.galleryproject.org/Gallery3:Modules:gallery"

--- a/modules/gallery/tests/Item_Model_Test.php
+++ b/modules/gallery/tests/Item_Model_Test.php
@@ -124,11 +124,54 @@ class Item_Model_Test extends Gallery_Unit_Test_Case {
     $this->assert_equal($fullsize_file, file_get_contents($photo->file_path()));
   }
 
-  public function item_rename_wont_accept_slash_test() {
+  public function photo_rename_wont_accept_slash_test() {
     $item = test::random_photo();
     $item->name = "/no_slashes/allowed/";
     $item->save();
     $this->assert_equal("no_slashes_allowed.jpg", $item->name);
+  }
+
+  public function photo_rename_wont_accept_backslash_test() {
+    $item = test::random_photo();
+    $item->name = "\\no_backslashes\\allowed\\";
+    $item->save();
+    $this->assert_equal("no_backslashes_allowed.jpg", $item->name);
+  }
+
+  public function album_rename_wont_accept_slash_test() {
+    try {
+      $item = test::random_album();
+      $item->name = "/no_album_slashes/allowed/";
+      $item->save();
+    } catch (ORM_Validation_Exception $e) {
+      $this->assert_same(array("name" => "no_slashes"), $e->validation->errors());
+      return;  // pass
+    }
+    $this->assert_true(false, "Shouldn't get here");
+  }
+
+  public function album_rename_wont_accept_backslash_test() {
+    try {
+      $item = test::random_album();
+      $item->name = "\\no_album_backslashes\\allowed\\";
+      $item->save();
+    } catch (ORM_Validation_Exception $e) {
+      $this->assert_same(array("name" => "no_backslashes"), $e->validation->errors());
+      return;  // pass
+    }
+    $this->assert_true(false, "Shouldn't get here");
+  }
+
+  public function album_rename_wont_accept_trailing_period_test() {
+    try {
+      $item = test::random_album();
+      $item->name = ".no_trailing_period.allowed.";
+      $item->save();
+    } catch (ORM_Validation_Exception $e) {
+      $this->assert_same(array("name" => "no_trailing_period"), $e->validation->errors());
+      return;  // pass
+    }
+    $this->assert_true(false, "Shouldn't get here");
   }
 
   public function move_album_test() {


### PR DESCRIPTION
- disallowed backslashes in item validation.
- refactored the validation logic in the item model a bit.
- added no_backslash error messages in edit album/photo/movie forms.
- fixed error messages in add album forum (some missing, some text different from edit)
- added unit tests
- updated to v58 to correct any existing backslashes in item names
