### PR TITLE
#2054 - Revise albums_form_add.js: update for new jQuery, refactor.

### DIFF
--- a/modules/gallery/js/albums_form_add.js
+++ b/modules/gallery/js/albums_form_add.js
@@ -1,23 +1,6 @@
-$("#g-add-album-form input[name=title]").change(
-  function() {
-    $("#g-add-album-form input[name=name]").attr(
-      "value", $("#g-add-album-form input[name=title]").attr("value")
-        .replace(/[\s\/]+/g, "-").replace(/\.+$/, ""));
-    $("#g-add-album-form input[name=slug]").attr(
-      "value", $("#g-add-album-form input[name=title]").attr("value")
-        .replace(/[^A-Za-z0-9-_]+/g, "-")
-	.replace(/^-+/, "")
-	.replace(/-+$/, ""));
-  });
-$("#g-add-album-form input[name=title]").keyup(
-  function() {
-    $("#g-add-album-form input[name=name]").attr(
-      "value", $("#g-add-album-form input[name=title]").attr("value")
-        .replace(/[\s\/]+/g, "-")
-	.replace(/\.+$/, ""));
-    $("#g-add-album-form input[name=slug]").attr(
-      "value", $("#g-add-album-form input[name=title]").attr("value")
-        .replace(/[^A-Za-z0-9-_]+/g, "-")
-	.replace(/^-+/, "")
-	.replace(/-+$/, ""));
-  });
+$("#g-add-album-form input[name='title']").on("input keyup", function() {
+  $("#g-add-album-form input[name='name']").val(
+    $(this).val().replace(/[\s\/\\]+/g, "-").replace(/\.+$/, ""));
+  $("#g-add-album-form input[name='slug']").val(
+    $(this).val().replace(/[^A-Za-z0-9-_]+/g, "-").replace(/^-+/, "").replace(/-+$/, ""));
+});


### PR DESCRIPTION
- changed "change" event to "input" to catch cut'n'paste
- kept "keyup" event for old IE compatibility
- removed code duplication by using $(this) and combining events using .on()
- replaced attr("value",...) with val()
- added quotes around input names
- disallowed backslashes
