### PR TITLE
Big update of how bootstrap and Module class load modules

### DIFF
--- a/application/bootstrap.php
+++ b/application/bootstrap.php
@@ -132,15 +132,26 @@ Kohana::$log->attach(new Log_File(VARPATH . "logs"), LOG_NOTICE);
 Kohana::$config->attach(new Config_File);
 
 /**
+ * Enable some core modules that are needed for the bootstrap.  We'll load the complete set later.
+ * Modules are referenced by a relative or absolute path.  Note that none of these modules
+ * have init.php files, so nothing should interfere with XSS cleaning happening first.
+ */
+Kohana::modules(array(
+  "purifier"    => MODPATH . "purifier",
+  "gallery"     => MODPATH . "gallery",
+  "cache"       => MODPATH . "cache",
+  "orm"         => MODPATH . "orm",
+  "database"    => MODPATH . "database"
+));
+
+/**
  * Protect against XSS.  This cleans $_GET, $_POST, and $_COOKIE and stores their raw values in
  * RAW::$_GET, RAW::$_POST, and RAW::$_COOKIE, respectively.  It also runs UTF8::clean() on
  * $_SERVER to remove control characters and convert to UTF8 if needed.
  *
- * This is run after Kohana's init (which calls Kohana::sanitize()), and requires that
- * we load *only* our purifier module.  For more details, see Purifier::clean_input_array().
+ * This is run after Kohana's init (which calls Kohana::sanitize()).  For more details,
+ * see Purifier::clean_input_array().
  */
-Kohana::modules(array("purifier" => MODPATH . "purifier"));
-
 class RAW {
   public static $_GET;
   public static $_POST;
@@ -157,28 +168,6 @@ if (isset($_SERVER["SERVER_NAME"])) {
   unset($_SERVER["HTTP_HOST"]);
 }
 $_SERVER = UTF8::clean($_SERVER);
-
-/**
- * Enable modules. Modules are referenced by a relative or absolute path.
- */
-Kohana::modules(array_merge(
-  (TEST_MODE ?
-    array(
-      "gallery_unit_test" => MODPATH . "gallery_unit_test",
-      "unit_test"         => MODPATH . "unit_test") :
-    array()),
-  array(
-    // The purifier module should always be first since it cannot be overridden.
-    // Since no other modules are activated yet, gallery goes next.  The other
-    // Kohana and 3rd-party modules go last so gallery can override them.
-    "purifier"    => MODPATH . "purifier",
-    "gallery"     => MODPATH . "gallery",
-    "database"    => MODPATH . "database",
-    "orm"         => MODPATH . "orm",
-    "cache"       => MODPATH . "cache",
-    "formo"       => MODPATH . "formo",
-    "pagination"  => MODPATH . "pagination")
-));
 
 // If var/database.php doesn't exist, then we assume that the Gallery is not properly installed
 // and send users to the installer.
@@ -220,6 +209,12 @@ Cookie::$secure = !empty($_SERVER["HTTPS"]) && ($_SERVER["HTTPS"] === "on");
 // @todo: should this be something different for each system?  Perhaps something tied
 // to the domain?
 Cookie::$salt = "g3";
+
+/**
+ * Enable the complete set of all active modules.  This will trigger each module to load its own
+ * init.php file which can, among other things, load its own routes which can override those below.
+ */
+Module::load_modules();
 
 // Set our routes.  Since there are the only two controller directories we use (root and admin), we
 // can remove all other underscores.  In Route::matches(), this filter is called *after* ucwords, so
@@ -266,9 +261,6 @@ Route::set("site", "(<controller>(/<action>))")
       "controller" => "albums",
       "action" => "index"
     ));
-
-// Load all active modules.  This will trigger each module to load its own routes.
-Module::load_modules();
 
 // Initialize I18n support
 I18n::lang('en-us');


### PR DESCRIPTION
- changed bootstrap to load a preliminary list needed for initialization, then
  leave the rest up to the Module class when Module::load_modules() is called,
  which includes unit test and third-party modules.
- changed Module class to consider two special modules, set by $_first_module
  and $_last_module variables (purifier and gallery, respectively).
- revised Module::_add_to_path() and Module::_remove_from_path() for K3.
- moved module loading in bootstrap before route definition so modules could
  override our defaults.
- fixed/added some comments.
