### PR TITLE
Move gallery_ready(), maintenance_mode(), and private_gallery() calls to Controller::before().

### DIFF
--- a/application/bootstrap.php
+++ b/application/bootstrap.php
@@ -213,6 +213,7 @@ Route::set("admin_forms", "form/<type>/<directory>/<controller>",
   ->filter(function($route, $params, $request) {
       $params["controller"] = str_replace("_", "", $params["controller"]);
       $params["action"] = "form_" . $params["type"];
+      $params["is_admin"] = true;
       return $params;
     });
 
@@ -228,6 +229,7 @@ Route::set("admin", "<directory>(/<controller>(/<action>))",
            array("directory" => "admin"))
   ->filter(function($route, $params, $request) {
       $params["controller"] = str_replace("_", "", $params["controller"]);
+      $params["is_admin"] = true;
       return $params;
     })
   ->defaults(array(

--- a/index.php
+++ b/index.php
@@ -120,11 +120,5 @@ if (file_exists("local.php")) {
 // Initialize the framework.
 require APPPATH . "bootstrap" . EXT;
 
-// Initialize the main request.
-$request = Request::factory(true, array(), false);
-
-// Initialize the gallery modules.
-Gallery::ready();
-
 // Go!
-echo $request->execute()->send_headers(true)->body();
+echo Request::factory(true, array(), false)->execute()->send_headers(true)->body();

--- a/modules/gallery/classes/Controller.php
+++ b/modules/gallery/classes/Controller.php
@@ -1,0 +1,3 @@
+<?php defined("SYSPATH") or die("No direct script access.");
+
+abstract class Controller extends Gallery_Controller {}

--- a/modules/gallery/classes/Gallery/Controller.php
+++ b/modules/gallery/classes/Gallery/Controller.php
@@ -1,0 +1,37 @@
+<?php defined("SYSPATH") or die("No direct script access.");
+/**
+ * Gallery - a web based photo album viewer and editor
+ * Copyright (C) 2000-2013 Bharat Mediratta
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+abstract class Gallery_Controller extends Kohana_Controller {
+  // Set the defaults as false (which can be overridden by other controllers)
+  public $allow_maintenance_mode = false;
+  public $allow_private_gallery = false;
+
+  public function before() {
+    parent::before();
+
+    // Initialize the modules (will run "gallery_ready" event)
+    if ($this->request->is_initial()) {
+      Gallery::ready();
+    }
+
+    // Check if we should be allowed to run this controller if in maintenance or private mode.
+    Gallery::maintenance_mode($this->allow_maintenance_mode);
+    Gallery::private_gallery($this->allow_private_gallery);
+  }
+}

--- a/modules/gallery/classes/Gallery/Controller/Combined.php
+++ b/modules/gallery/classes/Gallery/Controller/Combined.php
@@ -18,8 +18,8 @@
  * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA  02110-1301, USA.
  */
 class Gallery_Controller_Combined extends Controller {
-  const ALLOW_MAINTENANCE_MODE = true;
-  const ALLOW_PRIVATE_GALLERY = true;
+  public $allow_maintenance_mode = true;
+  public $allow_private_gallery = true;
 
   /**
    * Return the combined Javascript bundle associated with the given key.

--- a/modules/gallery/classes/Gallery/Controller/FileProxy.php
+++ b/modules/gallery/classes/Gallery/Controller/FileProxy.php
@@ -27,7 +27,8 @@
  * input is sanitized against the database before we perform any file I/O.
  */
 class Gallery_Controller_FileProxy extends Controller {
-  const ALLOW_PRIVATE_GALLERY = true;
+  public $allow_private_gallery = true;
+
   public function __call($function, $args) {
 
     // Force zlib compression off.  Image and movie files are already compressed and

--- a/modules/gallery/classes/Gallery/Controller/Login.php
+++ b/modules/gallery/classes/Gallery/Controller/Login.php
@@ -18,8 +18,8 @@
  * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA  02110-1301, USA.
  */
 class Gallery_Controller_Login extends Controller {
-  const ALLOW_MAINTENANCE_MODE = true;
-  const ALLOW_PRIVATE_GALLERY = true;
+  public $allow_maintenance_mode = true;
+  public $allow_private_gallery = true;
 
   public function action_ajax() {
     $view = new View("gallery/login_ajax.html");

--- a/modules/gallery/classes/Gallery/Hook/GalleryEvent.php
+++ b/modules/gallery/classes/Gallery/Hook/GalleryEvent.php
@@ -248,7 +248,7 @@ class Gallery_Hook_GalleryEvent {
                       ->url(UserProfile::url($user->id))
                       ->label($user->display_name()));
 
-        if (Route::$controller == "admin") {
+        if (Theme::$is_admin) {
           $continue_url = URL::abs_site("");
         } else if ($item = $theme->item()) {
           if (Access::user_can(Identity::guest(), "view", $theme->item)) {

--- a/modules/gallery/classes/Gallery/Theme.php
+++ b/modules/gallery/classes/Gallery/Theme.php
@@ -33,14 +33,11 @@ class Gallery_Theme {
    * active for any given request.
    */
   static function load_themes() {
-    // We haven't executed the request yet, so we use $initial instead of $current.
-    $path = Request::$initial->uri();
-    $override = Request::$initial->query("theme");
+    $override = Request::$current->query("theme");
+    self::$is_admin = Request::$current->param("is_admin", false);
+    self::$site_theme_name = Module::get_var("gallery", "active_site_theme");
 
     $modules = Kohana::modules();
-
-    self::$is_admin = $path == "/admin" || !strncmp($path, "/admin/", 7);
-    self::$site_theme_name = Module::get_var("gallery", "active_site_theme");
 
     // If the site theme doesn't exist, fall back to wind.
     if (!file_exists(THEMEPATH . self::$site_theme_name . "/theme.info")) {

--- a/modules/rest/classes/Rest/Controller/Rest.php
+++ b/modules/rest/classes/Rest/Controller/Rest.php
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA  02110-1301, USA.
  */
 class Rest_Controller_Rest extends Controller {
-  const ALLOW_PRIVATE_GALLERY = true;
+  public $allow_private_gallery = true;
 
   public function action_index() {
     $username = Request::$current->post("user");

--- a/modules/user/classes/User/Controller/Password.php
+++ b/modules/user/classes/User/Controller/Password.php
@@ -18,8 +18,8 @@
  * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA  02110-1301, USA.
  */
 class User_Controller_Password extends Controller {
-  const ALLOW_MAINTENANCE_MODE = true;
-  const ALLOW_PRIVATE_GALLERY = true;
+  public $allow_maintenance_mode = true;
+  public $allow_private_gallery = true;
 
   public function action_reset() {
     $form = self::_reset_form();


### PR DESCRIPTION
- add Gallery_Controller which extends Kohana_Controller (so it is inherited by every controller)
- add Controller::before() which calls the three functions above.
- change ALLOW_PRIVATE_GALLERY and ALLOW_MAINTENANCE_MODE to Controller class variables.
- use the newly-changed variables in maintenance_mode() and private_gallery()
  instead of ReflectionClass calls.
- remove Gallery::ready() from index.php.
- add "is_admin" parameter to admin-specific routes in bootstrap.
- use "is_admin" to set Theme::$is_admin, and call it later when needed.
- change Theme::load_themes() to use current request, not initial.
- add todo notes for K3 login rerouting.
