### PR TITLE
Add routing for items.

### DIFF
--- a/modules/gallery/classes/Gallery/Controller/Albums.php
+++ b/modules/gallery/classes/Gallery/Controller/Albums.php
@@ -18,11 +18,13 @@
  * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA  02110-1301, USA.
  */
 class Gallery_Controller_Albums extends Controller_Items {
-  public function action_index() {
-    $this->show(ORM::factory("Item", 1));
-  }
-
-  public function show($album) {
+  public function action_show() {
+    $album = $this->request->param("item");
+    if (!is_object($album)) {
+      // action_show() must be a public action because we route to it in the bootstrap,
+      // so make sure that we're actually receiving an object
+      throw HTTP_Exception::factory(404);
+    }
     Access::required("view", $album);
 
     $page_size = Module::get_var("gallery", "page_size", 9);

--- a/modules/gallery/classes/Gallery/Controller/Movies.php
+++ b/modules/gallery/classes/Gallery/Controller/Movies.php
@@ -18,7 +18,13 @@
  * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA  02110-1301, USA.
  */
 class Gallery_Controller_Movies extends Controller_Items {
-  public function show($movie) {
+  public function action_show() {
+    $movie = $this->request->param("item");
+    if (!is_object($movie)) {
+      // action_show() must be a public action because we route to it in the bootstrap,
+      // so make sure that we're actually receiving an object
+      throw HTTP_Exception::factory(404);
+    }
     Access::required("view", $movie);
 
     $template = new View_Theme("required/page.html", "item", "movie");

--- a/modules/gallery/classes/Gallery/Controller/Photos.php
+++ b/modules/gallery/classes/Gallery/Controller/Photos.php
@@ -18,7 +18,13 @@
  * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA  02110-1301, USA.
  */
 class Gallery_Controller_Photos extends Controller_Items {
-  public function show($photo) {
+  public function action_show() {
+    $photo = $this->request->param("item");
+    if (!is_object($photo)) {
+      // action_show() must be a public action because we route to it in the bootstrap,
+      // so make sure that we're actually receiving an object
+      throw HTTP_Exception::factory(404);
+    }
     Access::required("view", $photo);
 
     $template = new View_Theme("required/page.html", "item", "photo");


### PR DESCRIPTION
- make the controller name required for the fourth case (i.e. no default).
- add fifth case to routes in bootstrap for items.
- make an empty url point to the root item, but an invalid url throws an error.
- revert back to using action_show() in Photos, Albums, and Movies controllers.
- revise action_show() to get item model from request.
- remove Albums controller action_index().
