### PR TITLE
Add args functionality to Controller and Request.

### DIFF
--- a/application/bootstrap.php
+++ b/application/bootstrap.php
@@ -208,8 +208,8 @@ Module::load_modules();
 // other underscores.  In Route::matches(), filters are called *after* ucwords, so
 // "admin/advanced_settings" maps to "Controller_Admin_AdvancedSettings" and "file_proxy" maps to
 // "Controller_FileProxy".
-Route::set("admin_forms", "form/<type>/<directory>/<controller>",
-           array("type" => "(edit|add)", "directory" => "admin"))
+Route::set("admin_forms", "form/<type>/<directory>/<controller>(/<args>)",
+           array("type" => "(edit|add)", "directory" => "admin", "args" => "[^.,;?\\n]++"))
   ->filter(function($route, $params, $request) {
       $params["controller"] = str_replace("_", "", $params["controller"]);
       $params["action"] = "form_" . $params["type"];
@@ -217,16 +217,16 @@ Route::set("admin_forms", "form/<type>/<directory>/<controller>",
       return $params;
     });
 
-Route::set("site_forms", "form/<type>/<controller>",
-           array("type" => "(edit|add)"))
+Route::set("site_forms", "form/<type>/<controller>(/<args>)",
+           array("type" => "(edit|add)", "args" => "[^.,;?\\n]++"))
   ->filter(function($route, $params, $request) {
       $params["controller"] = str_replace("_", "", $params["controller"]);
       $params["action"] = "form_" . $params["type"];
       return $params;
     });
 
-Route::set("admin", "<directory>(/<controller>(/<action>))",
-           array("directory" => "admin"))
+Route::set("admin", "<directory>(/<controller>(/<action>(/<args>)))",
+           array("directory" => "admin", "args" => "[^.,;?\\n]++"))
   ->filter(function($route, $params, $request) {
       $params["controller"] = str_replace("_", "", $params["controller"]);
       $params["is_admin"] = true;
@@ -237,7 +237,8 @@ Route::set("admin", "<directory>(/<controller>(/<action>))",
       "action" => "index"
     ));
 
-Route::set("site", "<controller>(/<action>)")
+Route::set("site", "<controller>(/<action>(/<args>))",
+           array("args" => "[^.,;?\\n]++"))
   ->filter(function($route, $params, $request) {
       if (substr($params["controller"], 0, 6) == "Admin_") {
         // Admin controllers are not available, except via /admin

--- a/modules/gallery/classes/Gallery/Controller.php
+++ b/modules/gallery/classes/Gallery/Controller.php
@@ -22,6 +22,9 @@ abstract class Gallery_Controller extends Kohana_Controller {
   public $allow_maintenance_mode = false;
   public $allow_private_gallery = false;
 
+  /**
+   * This is run to initialize Gallery before executing the controller action.
+   */
   public function before() {
     parent::before();
 
@@ -33,5 +36,52 @@ abstract class Gallery_Controller extends Kohana_Controller {
     // Check if we should be allowed to run this controller if in maintenance or private mode.
     Gallery::maintenance_mode($this->allow_maintenance_mode);
     Gallery::private_gallery($this->allow_private_gallery);
+  }
+
+  /**
+   * Retrieves a value from the route args.  This is an alias of $this->request->arg().
+   *
+   *   $args = $this->arg();          // Returns all args
+   *   $id   = $this->arg(0);         // Returns 0th arg
+   *   $type = $this->arg(1, "item"); // Returns 1st arg, defaults to "item" if not set
+   *
+   * @param   mixed  $key      Key of the value (string or int)
+   * @param   mixed  $default  Default value if the key is not set (optional)
+   * @return  mixed
+   */
+  public function arg($key=null, $default=null) {
+    return $this->request->arg($key, $default);
+  }
+
+  /**
+   * Retrieves a value from the route args, and throws an HTTP 400 Bad Request error if not found.
+   * Optionally, a rule argument can be specified that sets further restrictions on the value and
+   * throws an HTTP 400 Bad Request if invalid.
+   *
+   *   $arg0 = $this->arg(0);               // must be defined (no further restrictions)
+   *   $id   = $this->arg(1, "digit");      // must be [0-9]; useful for ids
+   *   $type = $this->arg(2, "alpha");      // must be [A-Za-z]; useful for types
+   *                                        // (e.g. movie, photo, item, group, tag,...)
+   *   $name = $this->arg(3, "alpha_dash"); // must be [A-Za-z0-9-_]; useful for module-like names
+   *                                        // (e.g. server_add, items_tag, admin_wind,...)
+   *
+   * Note that the names "digit", "alpha", and "alpha_dash" are similar to their like-named
+   * functions in the Valid class, except that the filters here are more restrictive in that they
+   * do not support UTF-8 and are locale-invariant (e.g. Valid::alpha() could pass "âçcéñts").
+   *
+   * @param   mixed  $key   Key of the value (string or int)
+   * @param   string $rule  Name Default value if the key is not set
+   * @return  mixed
+   */
+  public function arg_required($key, $rule=null) {
+    $value = $this->request->arg($key);
+    if (is_null($value) ||
+        (($rule == "digit")      && preg_match("/[^0-9]/", $value)) ||
+        (($rule == "alpha")      && preg_match("/[^A-Za-z]/", $value)) ||
+        (($rule == "alpha_dash") && preg_match("/[^A-Za-z0-9-_]/", $value))) {
+      throw HTTP_Exception::factory(400);
+    }
+
+    return $value;
   }
 }

--- a/modules/gallery/classes/Gallery/Request.php
+++ b/modules/gallery/classes/Gallery/Request.php
@@ -1,0 +1,43 @@
+<?php defined("SYSPATH") or die("No direct script access.");
+/**
+ * Gallery - a web based photo album viewer and editor
+ * Copyright (C) 2000-2013 Bharat Mediratta
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+class Gallery_Request extends Kohana_Request {
+  protected $_args;
+
+  /**
+   * Retrieves a value from the route args.  This uses a syntax similar to param().
+   *
+   *   $args = $request->arg();          // Returns all args
+   *   $id   = $request->arg(0);         // Returns 0th arg
+   *   $type = $request->arg(1, "item"); // Returns 1st arg, defaults to "item" if not set
+   *
+   * @param   mixed  $key      Key of the value (string or int)
+   * @param   mixed  $default  Default value if the key is not set (optional)
+   * @return  mixed
+   */
+  public function arg($key=null, $default=null) {
+    if (!isset($this->_args)) {
+      $this->_args = preg_replace("|/+|", "/", trim($this->param("args"), "/"));
+      $this->_args = (array) explode("/", $this->_args);
+      $this->_args = Purifier::clean_html($this->_args);
+    }
+
+    return isset($key) ? Arr::get($this->_args, $key, $default) : $this->_args;
+  }
+}

--- a/modules/gallery/classes/Request.php
+++ b/modules/gallery/classes/Request.php
@@ -1,0 +1,3 @@
+<?php defined("SYSPATH") or die("No direct script access.");
+
+class Request extends Gallery_Request {}


### PR DESCRIPTION
- add Request::arg() to get, clean, and return args from Request::param().
- add Controller::arg() as alias of Request::arg()
- add Controller::arg_required() to get arg or throw HTTP 400 if missing/invalid.
- revise bootstrap to include args in the routes.
