### PR TITLE
Move generate-title-if-missing code to Model_Item.

### DIFF
--- a/modules/gallery/classes/Gallery/Controller/Albums.php
+++ b/modules/gallery/classes/Gallery/Controller/Albums.php
@@ -165,12 +165,6 @@ class Gallery_Controller_Albums extends Controller_Items {
 
     // Load and validate the form.
     if ($form->load()->validate()) {
-      // Set a default title if none given.
-      // @todo: consider moving this to the item model.
-      if (!$form->item->title->val()) {
-        $form->item->title->val($form->item->name->val());
-      }
-
       // Build the item model.
       $item = ORM::factory("Item");
       $item->parent_id = $parent_id;

--- a/modules/gallery/classes/Gallery/Controller/Uploader.php
+++ b/modules/gallery/classes/Gallery/Controller/Uploader.php
@@ -61,7 +61,6 @@ class Gallery_Controller_Uploader extends Controller {
       try {
         $item = ORM::factory("Item");
         $item->name = substr(basename($temp_filename), 10);  // Skip unique identifier Kohana adds
-        $item->title = Item::convert_filename_to_title($item->name);
         $item->parent_id = $album->id;
         $item->set_data_file($temp_filename);
 

--- a/modules/gallery/classes/Gallery/Item.php
+++ b/modules/gallery/classes/Gallery/Item.php
@@ -123,7 +123,7 @@ class Gallery_Item {
     $title = strtr($filename, "_", " ");
     $title = preg_replace("/\..{3,4}$/", "", $title);
     $title = preg_replace("/ +/", " ", $title);
-    return $title;
+    return trim($title);
   }
 
   /**

--- a/modules/gallery/classes/Gallery/Model/Item.php
+++ b/modules/gallery/classes/Gallery/Model/Item.php
@@ -417,6 +417,17 @@ class Gallery_Model_Item extends ORM_MPTT {
       }
     }
 
+    // Give the item a title, if necessary
+    if (!empty($this->title)) {
+      $this->title = Item::convert_filename_to_title($this->name);
+
+      // If the filename got converted away to nothing (e.g. "_.jpg"),
+      // revert to using the un-converted filename.
+      if (empty($this->title)) {
+        $this->title = $this->name;
+      }
+    }
+
     $this->_check_and_fix_conflicts();
 
     parent::create($validation);

--- a/modules/gallery/tests/Item_Model_Test.php
+++ b/modules/gallery/tests/Item_Model_Test.php
@@ -373,10 +373,10 @@ class Item_Model_Test extends Unittest_Testcase {
     $item->description = str_repeat("x", 70000);  // invalid
     $item->name = null;
     $item->parent_id = Random::int();
-    $item->slug = null;
+    $item->slug = null;  // gets auto-generated, no error
     $item->sort_column = "bogus";
     $item->sort_order = "bogus";
-    $item->title = null;
+    $item->title = null;  // gets auto-generated, no error
     $item->type = "bogus";
     try {
       $item->save();
@@ -385,7 +385,6 @@ class Item_Model_Test extends Unittest_Testcase {
       $errors = $e->errors();
       $this->assertEquals("max_length", $errors["description"][0]);
       $this->assertEquals("not_empty", $errors["name"][0]);
-      $this->assertEquals("not_empty", $errors["title"][0]);
       $this->assertEquals("invalid_item", $errors["album_cover_item_id"][0]);
       $this->assertEquals("invalid", $errors["parent_id"][0]);
       $this->assertEquals("invalid", $errors["sort_column"][0]);

--- a/modules/gallery/tests/Item_Test.php
+++ b/modules/gallery/tests/Item_Test.php
@@ -45,6 +45,8 @@ class Item_Test extends Unittest_TestCase {
   public function test_convert_filename_to_title() {
     $this->assertEquals("foo", Item::convert_filename_to_title("foo.jpg"));
     $this->assertEquals("foo.bar", Item::convert_filename_to_title("foo.bar.jpg"));
+    $this->assertEquals("foo", Item::convert_filename_to_title("_ foo.jpg"));
+    $this->assertEquals("", Item::convert_filename_to_title("_.jpg"));
   }
 
   public function test_convert_filename_to_slug() {

--- a/modules/server_add/classes/ServerAdd/Controller/ServerAdd.php
+++ b/modules/server_add/classes/ServerAdd/Controller/ServerAdd.php
@@ -241,13 +241,11 @@ class ServerAdd_Controller_ServerAdd extends Controller_Admin {
         }
 
         $name = basename($entry->path);
-        $title = Item::convert_filename_to_title($name);
         if ($entry->is_directory) {
           $album = ORM::factory("Item");
           $album->type = "album";
           $album->parent_id = $parent->id;
           $album->name = $name;
-          $album->title = $title;
           $album->owner_id = $owner_id;
           $album->sort_order = $parent->sort_order;
           $album->sort_column = $parent->sort_column;
@@ -262,7 +260,6 @@ class ServerAdd_Controller_ServerAdd extends Controller_Admin {
               $photo->parent_id = $parent->id;
               $photo->set_data_file($entry->path);
               $photo->name = $name;
-              $photo->title = $title;
               $photo->owner_id = $owner_id;
               $photo->save();
               $entry->item_id = $photo->id;
@@ -272,7 +269,6 @@ class ServerAdd_Controller_ServerAdd extends Controller_Admin {
               $movie->parent_id = $parent->id;
               $movie->set_data_file($entry->path);
               $movie->name = $name;
-              $movie->title = $title;
               $movie->owner_id = $owner_id;
               $movie->save();
               $entry->item_id = $movie->id;


### PR DESCRIPTION
- add code to Model_Item::create(), similar to how generate-slug-if-missing.
- remove same code from server_add, uploader, and add albums form.
- add trim() to Item::convert_filename_to_title() to avoid titles like " ".
- revise Item_Model_Test to reflect changes.
- add to Item_Test to reflect changes.
