### PR TITLE
Bootstrap fails badly when the var/log or var/cache directories are not ...

### DIFF
--- a/application/bootstrap.php
+++ b/application/bootstrap.php
@@ -169,12 +169,6 @@ if (isset($_SERVER["SERVER_NAME"])) {
 }
 $_SERVER = UTF8::clean($_SERVER);
 
-// If var/database.php doesn't exist, then we assume that the Gallery is not properly installed
-// and send users to the installer.
-if (!file_exists(VARPATH . "database.php")) {
-  HTTP::redirect(URL::abs_file("installer"));
-}
-
 // Simple and cheap test to make sure that the database config is ok.  Do this before we do
 // anything else database related.
 try {

--- a/index.php
+++ b/index.php
@@ -104,6 +104,12 @@ if (PHP_SAPI == "cli") {
 } else {
   define("TEST_MODE", 0);
   define("VARPATH", realpath("var") . "/");
+  // If var/database.php doesn't exist, then we assume that the Gallery is not properly installed
+  // and send users to the installer.
+  if (!file_exists(VARPATH . "database.php")) {
+    header("location: installer");
+    exit;
+  }
 }
 
 define("TMPPATH", VARPATH . "tmp/");


### PR DESCRIPTION
...set up.  Our instructions only say to create the var directory. So we need to catch it much earlier that gallary has not been initialized and redirect to the installer prior to initializing the KOhana framework.
