### PR TITLE
Add file extension to combined css/js links for better CDN caching

### DIFF
--- a/modules/gallery/libraries/Gallery_View.php
+++ b/modules/gallery/libraries/Gallery_View.php
@@ -157,7 +157,7 @@ class Gallery_View_Core extends View {
         // 7 == size, 9 == mtime, see http://php.net/stat
         $key[] = "$path $stats[7] $stats[9]";
       }
-      $key = md5(join(" ", $key));
+      $key = md5(join(" ", $key)) . (($type=="css") ? ".css" : ".js");
 
       if (gallery::allow_css_and_js_combining()) {
         // Combine enabled - if we're at the start of the buffer, add a comment.


### PR DESCRIPTION
Some CDN's like Cloudflare, are caching files according to file extension and not content-type. Adding an extension allows hit their rules.
