### PR TITLE
Move "item_moved" event later in the item update process.  Fixes #2077.

### DIFF
--- a/modules/gallery/helpers/item.php
+++ b/modules/gallery/helpers/item.php
@@ -63,11 +63,6 @@ class item_Core {
         break;
       }
     }
-
-    // If the target has no cover item, make this it.
-    if ($target->album_cover_item_id == null)  {
-      item::make_album_cover($source);
-    }
   }
 
   static function make_album_cover($item) {

--- a/modules/gallery/models/item.php
+++ b/modules/gallery/models/item.php
@@ -498,11 +498,6 @@ class Item_Model_Core extends ORM_MPTT {
             @rename($original->resize_path(), $this->resize_path());
             @rename($original->thumb_path(), $this->thumb_path());
           }
-
-          if ($original->parent_id != $this->parent_id) {
-            // This will result in 2 events since we'll still fire the item_updated event below
-            module::event("item_moved", $this, $original->parent());
-          }
         }
 
         // Changing the name, slug or parent ripples downwards
@@ -524,6 +519,11 @@ class Item_Model_Core extends ORM_MPTT {
           copy($this->data_file, $this->file_path());
           $this->thumb_dirty = 1;
           $this->resize_dirty = 1;
+        }
+
+        if ($original->parent_id != $this->parent_id) {
+          // This will result in 2 events since we'll still fire the item_updated event below
+          module::event("item_moved", $this, $original->parent());
         }
 
         module::event("item_updated", $original, $this);


### PR DESCRIPTION
Before, this was before the children's caches were cleared, so if the
"item_moved" set an album cover, it would fail with an invalid path.  For the
same reason, we move it after the data file update, too.  Lastly, get we get
rid of duplicated code in item::move() since the "item_moved" event already
does this.
