### PR TITLE
remove obsolete CSS class from upload form message-block

### DIFF
--- a/modules/gallery/views/form_uploadify.html.php
+++ b/modules/gallery/views/form_uploadify.html.php
@@ -120,7 +120,7 @@
 
 <div class="requires-flash">
   <? if ($suhosin_session_encrypt || (identity::active_user()->admin && !$movies_allowed)): ?>
-  <div class="g-message-block g-info">
+  <div class="g-message-block">
     <? if ($suhosin_session_encrypt): ?>
     <p class="g-error">
       <?= t("Error: your server is configured to use the <a href=\"%encrypt_url\"><code>suhosin.session.encrypt</code></a> setting from <a href=\"%suhosin_url\">Suhosin</a>.  You must disable this setting to upload photos.",


### PR DESCRIPTION
I removed this class because it is messing up my custom theme. It is obsolete because all possible child nodes have their own _»message«_ class **.g-error**.

I would love to see this class disappear because it looks wrong or at least misused here to me. There are no styling effects to the default theme by removing it because all rules are overridden by the child node rules anyway.

kind regards,
Moritz
